### PR TITLE
gormの基礎作成(dog_ownerのcreateのみ)

### DIFF
--- a/cmd/wanrun.go
+++ b/cmd/wanrun.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/wanrun-develop/wanrun/internal/db"
+	"github.com/wanrun-develop/wanrun/internal/dogOwner/adapters/repository"
+	"github.com/wanrun-develop/wanrun/internal/dogOwner/core"
+	"gorm.io/gorm"
 )
 
 func Main() {
@@ -24,5 +27,21 @@ func Main() {
 		return c.String(http.StatusOK, "Hello, World!!!!!")
 	})
 
+	rooting(e, dbConn)
+
 	e.Logger.Fatal(e.Start(":8080"))
+}
+
+/*
+	ルーティング設定
+*/
+func rooting(e *echo.Echo, dbConn *gorm.DB) {
+
+	//repository作成
+	dogOwnerRepository := repository.NewDogOwnerRepository(dbConn)
+	//handler作成
+	dogOwnerhandler := core.NewDogOwnerHandler(dogOwnerRepository)
+
+	dogOwnerG := e.Group("/dogowner")
+	dogOwnerG.POST("/create", dogOwnerhandler.CreateDogOwner)
 }

--- a/docs/db/gorm_struct.go
+++ b/docs/db/gorm_struct.go
@@ -1,0 +1,100 @@
+package temp
+
+import (
+	"time"
+)
+
+type DogOwner struct {
+	DogOwnerID int       `gorm:"primaryKey;column:dog_owner_id;autoIncrement"`
+	Name       string    `gorm:"size:128;column:name;not null"`
+	Email      string    `gorm:"size:255;column:email;not null"`
+	Image      string    `gorm:"type:text;column:image"`
+	Sex        string    `gorm:"size:1;column:sex"`
+	CreateAt   time.Time `gorm:"column:reg_at;not null;autoCreateTime"`
+	UpdateAt   time.Time `gorm:"column:upd_at;not null;autoCreateTime"`
+}
+
+type Dog struct {
+	DogID      int       `gorm:"primaryKey;column:dog_id;autoIncrement"`
+	DogOwnerID int       `gorm:"column:dog_owner_id;not null;foreignKey:DogOwnerID"`
+	Name       string    `gorm:"size:128;column:name;not null"`
+	DogTypeID  int       `gorm:"column:dog_type_id"`
+	Weight     int       `gorm:"column:weight"`
+	Sex        string    `gorm:"size:1;column:sex"`
+	Image      string    `gorm:"type:text;column:image"`
+	CreateAt   time.Time `gorm:"column:reg_at;not null;autoCreateTime"`
+	UpdateAt   time.Time `gorm:"column:upd_at;not null;autoCreateTime"`
+}
+
+type DogTypeMst struct {
+	DogTypeID int    `gorm:"primaryKey;column:dog_type_id;autoIncrement"`
+	Name      string `gorm:"size:64;column:name;not null"`
+}
+
+type InjectionCertification struct {
+	InjectionCertificationID int       `gorm:"primaryKey;column:injection_certification_id;autoIncrement"`
+	DogID                    int       `gorm:"column:dog_id;not null;foreignKey:DogID"`
+	Type                     int       `gorm:"column:type;not null"`
+	File                     string    `gorm:"type:text;column:file;not null"`
+	CreateAt                 time.Time `gorm:"column:reg_at;not null;autoCreateTime"`
+	UpdateAt                 time.Time `gorm:"column:upd_at;not null;autoCreateTime"`
+}
+
+type DogrunManager struct {
+	DogrunManagerID int       `gorm:"primaryKey;column:dogrun_manager_id;autoIncrement"`
+	Name            string    `gorm:"size:128;column:name"`
+	Email           string    `gorm:"size:255;column:email;not null"`
+	CreateAt        time.Time `gorm:"column:reg_at;not null;autoCreateTime"`
+	UpdateAt        time.Time `gorm:"column:upd_at;not null;autoCreateTime"`
+}
+
+type Dogrun struct {
+	DogrunID        int       `gorm:"primaryKey;column:dogrun_id;autoIncrement"`
+	DogrunManagerID int       `gorm:"column:dogrun_manager_id;foreignKey:DogrunManagerID"`
+	Name            string    `gorm:"size:256;column:name;not null"`
+	Address         string    `gorm:"size:256;column:address"`
+	PostCode        string    `gorm:"size:8;column:postcode"`
+	BusinessDay     int       `gorm:"column:business_day"`
+	Holiday         int       `gorm:"column:holiday"`
+	OpenTime        time.Time `gorm:"column:open_time"`
+	CloseTime       time.Time `gorm:"column:close_time"`
+	Description     string    `gorm:"type:text;column:description"`
+	CreateAt        time.Time `gorm:"column:reg_at;not null;autoCreateTime"`
+	UpdateAt        time.Time `gorm:"column:upd_at;not null;autoCreateTime"`
+}
+
+type DogrunImage struct {
+	DogrunImageID int       `gorm:"primaryKey;column:dogrun_image_id;autoIncrement"`
+	DogrunID      int       `gorm:"column:dogrun_id;not null;foreignKey:DogrunID"`
+	Image         string    `gorm:"type:text;column:image;not null"`
+	SortOrder     int       `gorm:"column:sort_order"`
+	UploadAt      time.Time `gorm:"column:upload_at"`
+}
+
+type DogrunTag struct {
+	DogrunTagID int `gorm:"primaryKey;column:dogrun_tag_id;autoIncrement"`
+	DogrunID    int `gorm:"column:dogrun_id;not null;foreignKey:DogrunID"`
+	TagID       int `gorm:"column:tag_id;not null;foreignKey:TagID"`
+}
+
+type TagMst struct {
+	TagID       int    `gorm:"primaryKey;column:tag_id;autoIncrement"`
+	TagName     string `gorm:"size:64;column:tag_name;not null"`
+	Description string `gorm:"type:text;column:description"`
+}
+
+type AuthDogOwner struct {
+	AuthDogOwnerID int       `gorm:"primaryKey;column:auth_dog_owner_id;autoIncrement"`
+	DogOwnerID     int       `gorm:"column:dog_owner_id;not null;foreignKey:DogOwnerID"`
+	Password       string    `gorm:"size:256;column:password"`
+	GrantType      int       `gorm:"column:grant_type;not null"`
+	LoginAt        time.Time `gorm:"column:login_at"`
+}
+
+type AuthDogrunManager struct {
+	AuthDogrunManagerID int       `gorm:"primaryKey;column:auth_dogrun_manager_id;autoIncrement"`
+	DogrunManagerID     int       `gorm:"column:dogrun_manager_id;not null;foreignKey:DogrunManagerID"`
+	Password            string    `gorm:"size:256;column:password"`
+	GrantType           int       `gorm:"column:grant_type;not null"`
+	LoginAt             time.Time `gorm:"column:login_at"`
+}

--- a/internal/dogOwner/adapters/repository/dog_owner_repository.go
+++ b/internal/dogOwner/adapters/repository/dog_owner_repository.go
@@ -1,0 +1,27 @@
+package repository
+
+import (
+	"github.com/wanrun-develop/wanrun/internal/dogOwner/core/models"
+	"gorm.io/gorm"
+)
+
+/*
+dog_ownerのrepositoryの作成
+*/
+type DogOwnerRepository struct {
+	dbConn *gorm.DB
+}
+
+/*
+repositoryの作成
+*/
+func NewDogOwnerRepository(dbConn *gorm.DB) *DogOwnerRepository {
+	return &DogOwnerRepository{dbConn: dbConn}
+}
+
+/*
+引数のmodels.DogOwnerをinsertする
+*/
+func (r *DogOwnerRepository) InsertDogOwner(dogOwner *models.DogOwner) {
+	r.dbConn.Create(&dogOwner)
+}

--- a/internal/dogOwner/core/dog_owner_handler.go
+++ b/internal/dogOwner/core/dog_owner_handler.go
@@ -1,0 +1,37 @@
+package core
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/wanrun-develop/wanrun/internal/dogOwner/adapters/repository"
+	"github.com/wanrun-develop/wanrun/internal/dogOwner/core/models"
+)
+
+/*
+dog_ownerのhandler
+*/
+type dogOwnerHandler struct {
+	repo *repository.DogOwnerRepository
+}
+
+/*
+handlerの作成
+*/
+func NewDogOwnerHandler(repo *repository.DogOwnerRepository) *dogOwnerHandler {
+	return &dogOwnerHandler{repo}
+}
+
+/*
+dog_ownerの作成
+*/
+func (h *dogOwnerHandler) CreateDogOwner(c echo.Context) error {
+
+	dogOwner := models.DogOwner{}
+
+	if err := c.Bind(&dogOwner); err != nil {
+		return err
+	}
+	h.repo.InsertDogOwner(&dogOwner)
+	return c.JSON(http.StatusCreated, dogOwner)
+}

--- a/internal/dogOwner/core/models/dog_owners.go
+++ b/internal/dogOwner/core/models/dog_owners.go
@@ -1,0 +1,18 @@
+package models
+
+import (
+	"time"
+)
+
+/*
+dog_ownerのgorm用構造体
+*/
+type DogOwner struct {
+	DogOwnerID int       `gorm:"primaryKey;column:dog_owner_id;autoIncrement"`
+	Name       string    `gorm:"size:128;column:name;not null"`
+	Email      string    `gorm:"size:255;column:email;not null"`
+	Image      string    `gorm:"type:text;column:image"`
+	Sex        string    `gorm:"size:1;column:sex"`
+	CreateAt   time.Time `gorm:"column:reg_at;not null;autoCreateTime"`
+	UpdateAt   time.Time `gorm:"column:upd_at;not null;autoCreateTime"`
+}


### PR DESCRIPTION
## 概要

gormを使用した基礎のの作成（模索ではある）

## 変更点

dog_ownerのcreateのみの作成

- ./internal/dogOwnerの作成
- ./doc/db/grom_struct.goの作成

## 影響範囲
特になし

## テスト
下記でのinsertの動作確認済み
```
POST:dogowner/create

{
	"name": "ドッグオーナー３",
	"email": "dog_owner3@dummy.com",
	"image": "dummy3",
	"sex": "1"
}
```

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- 関連Issue: #20 
