### PR TITLE
ホットリロードで開発ができるようにAirの実装

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,53 @@
+# Config file for [Air](https://github.com/cosmtrek/air) in TOML format
+
+# Working directory
+# . or absolute path, please note that the directories following must be under root.
+root = "."
+tmp_dir = "tmp"
+
+[build]
+# Just plain old shell command. You could use `make` as well.
+cmd = "go build -o main ./cmd/wanrun/main.go"
+# Binary file yields from `cmd`.
+bin = "."
+# Customize binary, can setup environment variables when run your app.
+full_bin = "APP_ENV=dev APP_USER=air ./main"
+# Watch these filename extensions.
+include_ext = ["go", "tpl", "tmpl", "html"]
+# Ignore these filename extensions or directories.
+exclude_dir = ["assets", "tmp", "vendor", "frontend/node_modules"]
+# Watch these directories if you specified.
+include_dir = []
+# Exclude files.
+exclude_file = []
+# Exclude specific regular expressions.
+exclude_regex = ["_test.go"]
+# Exclude unchanged files.
+exclude_unchanged = true
+# Follow symlink for directories
+follow_symlink = true
+# This log file places in your tmp_dir.
+log = "air.log"
+# It's not necessary to trigger build each time file changes if it's too frequent.
+delay = 1000 # ms
+# Stop running old binary when build errors occur.
+stop_on_error = true
+# Send Interrupt signal before killing process (windows does not support this feature)
+send_interrupt = false
+# Delay after sending Interrupt signal
+kill_delay = 500 # ms
+
+[log]
+# Show log time
+time = false
+
+[color]
+# Customize each part's color. If no color found, use the raw app log.
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+##
+## Specific to .dockerignore
+##
+
+.git/
+.github/
+Dockerfile
+
+# Test binary, build with `go test -c`
+# *.test
+
+# original
+.vscode
+docker-compose.yml
+.dockerignore
+**/README.md
+docs/
+migrate/
+.env*

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 # Go workspace file
 go.work
 go.work.sum
+main

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,35 @@
-FROM golang:1.22.1 AS builder
+# ============
+# Dev
+# ============
+FROM golang:1.22.1 as Dev
+ENV TZ=Asia/Tokyo
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
+ENV ROOTPATH=/app
+ENV PATH="PATH=$PATH:/go/bin/linux_amd64"
+
+WORKDIR ${ROOTPATH}
+
+RUN go install github.com/air-verse/air@latest
+COPY go.mod go.sum .air.toml ./
+RUN go mod download
+
+COPY . .
+EXPOSE 8080
+
+CMD ["air", "-c", ".air.toml"]
+# CMD ["sh", "-c", "sleep 3600"] # debug用
+
+# ============
+# Builder
+# ============
+FROM golang:1.22.1 AS Builder
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
 
 WORKDIR /app
 # ENV GO111MODULE=on
@@ -17,15 +48,18 @@ WORKDIR /app/cmd/wanrun
 RUN go build -o main main.go
 # RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/app
 
-FROM golang:1.22.1
+# ============
+# Deploy
+# ============
+FROM golang:1.22.1 AS Deploy
 WORKDIR /app
 # FROM alpine:3.20.1
 ENV TZ /usr/share/zoneinfo/Asia/Tokyo
 
-COPY --from=builder /etc/group /etc/group
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /app/cmd/wanrun/main ./main
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=Builder /etc/group /etc/group
+COPY --from=Builder /etc/passwd /etc/passwd
+COPY --from=Builder /app/cmd/wanrun/main ./main
+COPY --from=Builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ target: Deploy
 docker compose up -d --build
 ```
 
-### 3. コンテナ２台の確認
+### 2.3 コンテナ２台の確認
 ```
 docker ps
 ```
+
+### FYI
+https://github.com/air-verse/air
 ---
 
 ## Local db migration

--- a/README.md
+++ b/README.md
@@ -25,13 +25,16 @@ target: Deploy
 docker compose up -d --build
 ```
 
-### 2.3 コンテナ２台の確認
+### 2.3 コンテナ２台の確認(backend, postgres)
+
 ```
 docker ps
 ```
 
-### FYI
+### 3. FYI
+
 https://github.com/air-verse/air
+
 ---
 
 ## Local db migration

--- a/README.md
+++ b/README.md
@@ -2,9 +2,33 @@
 
 ## docker command
 
-### Postgres立ち上げとEchoの立ち上げ
-docker compose up -d --build
+### 1. postgresのマウント用のフォルダ作成
 
+```
+mkdir -p /var/postgres
+```
+### 2.1 ホットリロードで開発するのか実行環境で立ち上げるのか
+`docker-compose.yaml`の`backendコンテナ`を下記に設定。
+**ホットリロードバージョン**
+```
+target: Dev
+```
+
+**実行環境で立ち上げたい場合**
+```
+target: Deploy
+```
+
+### 2.2 Postgres立ち上げとEchoの立ち上げ
+
+```
+docker compose up -d --build
+```
+
+### 3. コンテナ２台の確認
+```
+docker ps
+```
 ---
 
 ## Local db migration

--- a/cmd/wanrun.go
+++ b/cmd/wanrun.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/wanrun-develop/wanrun/internal/db"
@@ -16,11 +17,15 @@ func Main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	fmt.Printf("DB info: %v", dbConn)
+	fmt.Printf("DB info: %v\n", dbConn)
 
 	defer db.CloseDB(dbConn)
-
-	message := fmt.Sprintf("%v", "Hello, World!!!!!!")
+	time := time.Now()
+	message := fmt.Sprintf(
+		"%v\nNowTime: %v",
+		"Hello, World!!!!!",
+		time)
+	log.Printf("NowTime: %v\n", time)
 
 	e.GET("/", func(c echo.Context) error {
 		return c.String(http.StatusOK, message)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,8 +22,8 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-      target: Dev # airを使ってホットリロードしたい場合
-      #target: Deploy # 実行環境で行いたい場合、コメントを外す
+      target: Dev # airを使ってホットリロードしたい場合(開発する際)
+      # target: Deploy # 本番実行環境で行いたい場合、コメントを外す
     stdin_open: true
     tty: true
     container_name: wanrun

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,10 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
+      target: Dev # airを使ってホットリロードしたい場合
+      #target: Deploy # 実行環境で行いたい場合、コメントを外す
+    stdin_open: true
+    tty: true
     container_name: wanrun
     ports:
       - 8080:8080
@@ -36,7 +40,7 @@ services:
       postgres:
         condition: service_healthy
     volumes:
-      - ./:/var/run
+      - ./:/app
     networks:
       - wanrun
 networks: 


### PR DESCRIPTION
## 概要

ホットリロードで開発ができるようにAirの実装
使い方は、`README.md`を見て
DEVのみだけなので、後日BuilderとDeploy修正します。
## 変更点
- dockerignoreファイルの追加
- Dockerfileでの仕様変更（開発だけのステージの用意）
- docker composeでのマウント指定変更

## 関連Issue
- 関連Issue: #28 
