### PR TITLE
メール重複の際のバリデーション

### DIFF
--- a/internal/auth/controller/auth_controller.go
+++ b/internal/auth/controller/auth_controller.go
@@ -35,7 +35,7 @@ func (ac *authController) SignUp(c echo.Context) error {
 
 	reqADOD := dto.ReqAuthDogOwnerDto{}
 
-  if err := c.Bind(&reqADOD); err != nil {
+	if err := c.Bind(&reqADOD); err != nil {
 		logger.Error(err)
 		return c.JSON(http.StatusBadRequest, errors.ErrorResponse{
 			Code:    http.StatusBadRequest,
@@ -45,6 +45,14 @@ func (ac *authController) SignUp(c echo.Context) error {
 
 	// dogOwnerのSignUp
 	resAuthDogOwner, err := ac.ah.SignUp(c, reqADOD)
+
+	// メール重複の場合
+	if err.Error() == "Email already exists" {
+		return c.JSON(http.StatusConflict, errors.ErrorResponse{
+			Code:    http.StatusConflict,
+			Message: "Email is already in use. Please use a different email.",
+		})
+	}
 
 	if err != nil {
 		logger.Error(err)


### PR DESCRIPTION
## 概要

メール重複の際のバリデーション

## 変更点
- DogOwnerを作成する前に既存のメールが存在するのか確認処理の追加
- レスポンスの際に、409と重複がわかるメッセージをフロントに返すように変更

## 関連Issue
- 関連Issue: #52 