### PR TITLE
#42 エラーハンドリング（一旦）

### DIFF
--- a/cmd/wanrun.go
+++ b/cmd/wanrun.go
@@ -6,6 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 
+	"github.com/wanrun-develop/wanrun/internal"
 	authRepository "github.com/wanrun-develop/wanrun/internal/auth/adapters/repository"
 	authController "github.com/wanrun-develop/wanrun/internal/auth/controller"
 	authHandler "github.com/wanrun-develop/wanrun/internal/auth/core/handler"
@@ -18,6 +19,7 @@ import (
 	dogrunC "github.com/wanrun-develop/wanrun/internal/dogrun/controller"
 	dogrunH "github.com/wanrun-develop/wanrun/internal/dogrun/core/handler"
 
+	"github.com/wanrun-develop/wanrun/pkg/errors"
 	logger "github.com/wanrun-develop/wanrun/pkg/log"
 	"gorm.io/gorm"
 )
@@ -45,13 +47,14 @@ func Main() {
 	// ミドルウェアを登録
 	e.Use(middleware.RequestID())
 	e.Use(logger.RequestLoggerMiddleware(zap))
+	e.HTTPErrorHandler = errors.HttpErrorHandler
 
 	// CORSの設定
 	e.Use(middleware.CORS())
 
 	// Router設定
 	newRouter(e, dbConn)
-	e.GET("/test", logger.Test)
+	e.GET("/test", internal.Test)
 
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/test.go
+++ b/internal/test.go
@@ -1,0 +1,31 @@
+package internal
+
+import (
+	"os"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/wanrun-develop/wanrun/pkg/errors"
+	"github.com/wanrun-develop/wanrun/pkg/log"
+)
+
+func Test(c echo.Context) error {
+	logger := log.GetLogger(c).Sugar()
+	logger.Info("Test*()の実行. ")
+	if err := testError(); err != nil {
+		err = errors.NewWRError(err, "エラー再生成しました。", errors.NewAuthClientErrorType())
+		logger.Error(err)
+		return err
+	}
+	return nil
+}
+
+func testError() error {
+	file := "xxx/xxx"
+	_, err := os.Open(file)
+	if err != nil {
+		err := errors.NewWRError(err, "エラー発生: entityFuncのファイル読み込み", errors.NewAuthClientErrorType())
+		return err
+	}
+	return nil
+}

--- a/internal/test.go
+++ b/internal/test.go
@@ -13,7 +13,7 @@ func Test(c echo.Context) error {
 	logger := log.GetLogger(c).Sugar()
 	logger.Info("Test*()の実行. ")
 	if err := testError(); err != nil {
-		err = errors.NewWRError(err, "エラー再生成しました。", errors.NewAuthClientErrorType())
+		err = errors.NewWRError(err, "エラー再生成しました。", errors.NewAuthClientErrorEType())
 		logger.Error(err)
 		return err
 	}
@@ -24,7 +24,7 @@ func testError() error {
 	file := "xxx/xxx"
 	_, err := os.Open(file)
 	if err != nil {
-		err := errors.NewWRError(err, "エラー発生: entityFuncのファイル読み込み", errors.NewAuthClientErrorType())
+		err := errors.NewWRError(err, "エラー発生: entityFuncのファイル読み込み", errors.NewAuthClientErrorEType())
 		return err
 	}
 	return nil

--- a/pkg/errors/errcode.go
+++ b/pkg/errors/errcode.go
@@ -3,10 +3,10 @@ package errors
 import "fmt"
 
 const (
-	AUTH     int = 1
-	DOG      int = 2
-	DOGOWNER int = 3
-	DOGRUN   int = 4
+	AUTH      int = 1
+	DOG       int = 2
+	DOG_OWNER int = 3
+	DOGRUN    int = 4
 )
 
 const (
@@ -14,68 +14,68 @@ const (
 	SERVER int = 2
 )
 
-type Type struct {
-	Service   int
-	ErrorType int
+type eType struct {
+	service   int
+	errorType int
 }
 
 /*
 認証機能のクライアントエラー
 */
-func NewAuthClientErrorType() Type {
-	return Type{AUTH, CLIENT}
+func NewAuthClientErrorEType() eType {
+	return eType{AUTH, CLIENT}
 }
 
 /*
 認証機能のサーバーエラー
 */
-func NewAuthSeverErrorType() Type {
-	return Type{AUTH, SERVER}
+func NewAuthSeverErrorEType() eType {
+	return eType{AUTH, SERVER}
 }
 
 /*
 ドッグ機能のクライアントエラー
 */
-func NewDogClientErrorType() Type {
-	return Type{DOG, CLIENT}
+func NewDogClientErrorEType() eType {
+	return eType{DOG, CLIENT}
 }
 
 /*
 ドッグ機能のサーバーエラー
 */
-func NewDogServerErrorType() Type {
-	return Type{DOG, SERVER}
+func NewDogServerErrorEType() eType {
+	return eType{DOG, SERVER}
 }
 
 /*
 ドッグオーナー機能のクライアントエラー
 */
-func NewDogownerClientErrorType() Type {
-	return Type{DOGOWNER, CLIENT}
+func NewDogownerClientErrorEType() eType {
+	return eType{DOG_OWNER, CLIENT}
 }
 
 /*
 ドッグオーナー機能のサーバーエラー
 */
-func NewDogownerServerErrorType() Type {
-	return Type{DOGOWNER, SERVER}
+func NewDogownerServerErrorEType() eType {
+	return eType{DOG_OWNER, SERVER}
 }
 
 /*
 ドッグラン機能のクライアントエラー
 */
-func NewDogrunClientErrorType() Type {
-	return Type{DOGRUN, CLIENT}
+func NewDogrunClientErrorEType() eType {
+	return eType{DOGRUN, CLIENT}
 }
 
 /*
 ドッグラン機能のサーバーエラー
 */
-func NewDogrunServerErrorType() Type {
-	return Type{DOGRUN, SERVER}
+func NewDogrunServerErrorEType() eType {
+	return eType{DOGRUN, SERVER}
 }
 
-func (t Type) String() string {
+func (t eType) String() string {
 	// カスタムフォーマットで文字列を返す
-	return fmt.Sprintf("%d-%d", t.Service, t.ErrorType)
+	return fmt.Sprintf("%d-%d", t.service, t.errorType)
 }

--- a/pkg/errors/errcode.go
+++ b/pkg/errors/errcode.go
@@ -1,0 +1,81 @@
+package errors
+
+import "fmt"
+
+const (
+	AUTH     int = 1
+	DOG      int = 2
+	DOGOWNER int = 3
+	DOGRUN   int = 4
+)
+
+const (
+	CLIENT int = 1
+	SERVER int = 2
+)
+
+type Type struct {
+	Service   int
+	ErrorType int
+}
+
+/*
+認証機能のクライアントエラー
+*/
+func NewAuthClientErrorType() Type {
+	return Type{AUTH, CLIENT}
+}
+
+/*
+認証機能のサーバーエラー
+*/
+func NewAuthSeverErrorType() Type {
+	return Type{AUTH, SERVER}
+}
+
+/*
+ドッグ機能のクライアントエラー
+*/
+func NewDogClientErrorType() Type {
+	return Type{DOG, CLIENT}
+}
+
+/*
+ドッグ機能のサーバーエラー
+*/
+func NewDogServerErrorType() Type {
+	return Type{DOG, SERVER}
+}
+
+/*
+ドッグオーナー機能のクライアントエラー
+*/
+func NewDogownerClientErrorType() Type {
+	return Type{DOGOWNER, CLIENT}
+}
+
+/*
+ドッグオーナー機能のサーバーエラー
+*/
+func NewDogownerServerErrorType() Type {
+	return Type{DOGOWNER, SERVER}
+}
+
+/*
+ドッグラン機能のクライアントエラー
+*/
+func NewDogrunClientErrorType() Type {
+	return Type{DOGRUN, CLIENT}
+}
+
+/*
+ドッグラン機能のサーバーエラー
+*/
+func NewDogrunServerErrorType() Type {
+	return Type{DOGRUN, SERVER}
+}
+
+func (t Type) String() string {
+	// カスタムフォーマットで文字列を返す
+	return fmt.Sprintf("%d-%d", t.Service, t.ErrorType)
+}

--- a/pkg/errors/response.go
+++ b/pkg/errors/response.go
@@ -1,6 +1,13 @@
 package errors
 
 type ErrorResponse struct {
-	Code    uint   `json:"code"`
-	Message string `json:"message"`
+	Code       uint   `json:"code"`
+	Message    string `json:"message"`
+	StackTrace string `json:"trace,omitempty"`
+}
+
+type ErrorRes struct {
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	StackTrace string `json:"trace,omitempty"`
 }

--- a/pkg/errors/wrerror.go
+++ b/pkg/errors/wrerror.go
@@ -1,0 +1,108 @@
+package errors
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// 認証型エラーコード
+const (
+	UnAuthorizedCode = "1-1-c"
+)
+
+type WRError struct {
+	Type       Type
+	CauseBy    string
+	Msg        string
+	InnerError error
+}
+
+func (me *WRError) Error() string {
+	return fmt.Sprintf("wanrun error: code[%s], message[%s]", me.Type, me.Msg)
+}
+
+func (e WRError) Format(f fmt.State, c rune) {
+	switch c {
+	case 'v':
+		fmt.Fprintf(f, "  code[%s]", e.Type)
+		fmt.Fprintf(f, "  message: %s", e.Msg)
+		fmt.Fprintf(f, " ->causeBy: %s", e.CauseBy)
+	default:
+		fmt.Fprintf(f, "%v", string(c))
+	}
+}
+
+/*
+エラー生成
+すでにWRErrorの場合は、そのまま返す
+*/
+func NewWRError(err error, msg string, ErrorType Type) *WRError {
+	if me, ok := err.(*WRError); ok {
+		return me
+	}
+	return &WRError{
+		Type:       ErrorType,
+		CauseBy:    err.Error(),
+		Msg:        msg,
+		InnerError: err,
+	}
+}
+
+/*
+カスタムエラーハンドラーミドルウェア
+*/
+func HttpErrorHandler(err error, c echo.Context) {
+	code := 500
+
+	var me *WRError
+	if wreer, ok := err.(*WRError); ok {
+		me = wreer
+		code = mappingError(me)
+	}
+
+	res := ErrorRes{
+		Code:       me.Type.String(),
+		Message:    me.Msg,
+		StackTrace: me.CauseBy,
+	}
+
+	if !c.Response().Committed {
+		if c.Request().Method == echo.HEAD {
+			err := c.NoContent(code)
+			if err != nil {
+				c.Logger().Error(err)
+			}
+		} else {
+			err := c.JSON(code, res)
+			if err != nil {
+				c.Logger().Error(err)
+			}
+		}
+	}
+}
+
+/*
+内部エラーコードどHTTPエラーコードのマッピング
+*/
+func mappingError(err *WRError) int {
+	errorType := err.Type
+
+	var httpCode int
+	switch errorType.ErrorType {
+	case CLIENT:
+		switch errorType.Service {
+		case AUTH:
+			httpCode = http.StatusUnauthorized //401
+		default:
+			httpCode = http.StatusBadRequest //400
+		}
+	case SERVER:
+		httpCode = http.StatusInternalServerError //500
+	default:
+		httpCode = http.StatusInternalServerError //500
+	}
+
+	return httpCode
+}


### PR DESCRIPTION
## 概要
エラーハンドリング処理作成
正直全然使いやすくはないので、今後磨いていこう

## 変更点

errorsのErrorResはミドルウェアで生成して返す。
ビジネスロジック等では、WRErrorを生成して、returnさせる。
errorをリターンさせると、ミドルウェアでエラーレスポンスに変えて返す。

ErrorResponseは削除予定だが、使ってる箇所があるので、そのままにしてる。（どっち残してもいいけど、ビジネスロジックでは、ErrorResponseを生成しないようにしたい）

## 影響範囲
なし

## テスト

なし
## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- 関連Issue: #42 
