### PR TITLE
fix: OAuthのDB構成

### DIFF
--- a/migrate/migration_sql/000001_dog_owners.up.sql
+++ b/migrate/migration_sql/000001_dog_owners.up.sql
@@ -5,6 +5,6 @@ CREATE TABLE IF NOT EXISTS dog_owners (
     phone_number varchar(15),  -- phone_numberもNULLを許可する
     image text,
     sex char(1),
-    reg_at timestamp not null default current_timestamp,
-    upd_at timestamp not null default current_timestamp
+    reg_at timestamp not null,
+    upd_at timestamp not null
 );

--- a/migrate/migration_sql/000001_dog_owners.up.sql
+++ b/migrate/migration_sql/000001_dog_owners.up.sql
@@ -1,9 +1,10 @@
 CREATE TABLE IF NOT EXISTS dog_owners (
     dog_owner_id serial primary key,
     name varchar(128) not null,
-    email varchar(255) unique not null,
+    email varchar(255) unique,  -- emailはユニークだが、NULLも許可される
+    phone_number varchar(15),  -- phone_numberもNULLを許可する
     image text,
     sex char(1),
-    reg_at timestamp not null,
-    upd_at timestamp not null
+    reg_at timestamp not null default current_timestamp,
+    upd_at timestamp not null default current_timestamp
 );

--- a/migrate/migration_sql/000001_dog_owners.up.sql
+++ b/migrate/migration_sql/000001_dog_owners.up.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS dog_owners (
     dog_owner_id serial primary key,
     name varchar(128) not null,
     email varchar(255) unique,  -- emailはユニークだが、NULLも許可される
-    phone_number varchar(15),  -- phone_numberもNULLを許可する
+    phone_number varchar(15) unique,  -- phone_numberもNULLを許可する
     image text,
     sex char(1),
     reg_at timestamp not null,

--- a/migrate/migration_sql/000010_auth_dog_owners.up.sql
+++ b/migrate/migration_sql/000010_auth_dog_owners.up.sql
@@ -2,7 +2,7 @@ CREATE TYPE grant_type_enum AS ENUM ('PASSWORD', 'OAUTH');
 
 CREATE TABLE IF NOT EXISTS auth_dog_owners (
     auth_dog_owner_id serial primary key,
-    dog_owner_id bigint not null references dog_owners(dog_owner_id),
+    dog_owner_id bigint not null,
     password varchar(256),  -- パスワード認証用のパスワード。OAuth認証の場合はNULL。
     email varchar(255),  -- パスワード認証で使うemail。OAuth認証の場合はNULL。
     phone_number varchar(15),  -- パスワード認証で使うphone_number。OAuth認証の場合はNULL。

--- a/migrate/migration_sql/000010_auth_dog_owners.up.sql
+++ b/migrate/migration_sql/000010_auth_dog_owners.up.sql
@@ -1,7 +1,14 @@
+CREATE TYPE grant_type_enum AS ENUM ('PASSWORD', 'OAUTH');
+
 CREATE TABLE IF NOT EXISTS auth_dog_owners (
     auth_dog_owner_id serial primary key,
-    dog_owner_id bigint not null,
-    password varchar(256),
-    grant_type int not null,
-    login_at timestamp
+    dog_owner_id bigint not null references dog_owners(dog_owner_id),
+    password varchar(256),  -- パスワード認証用のパスワード。OAuth認証の場合はNULL。
+    email varchar(255),  -- パスワード認証で使うemail。OAuth認証の場合はNULL。
+    phone_number varchar(15),  -- パスワード認証で使うphone_number。OAuth認証の場合はNULL。
+    grant_type grant_type_enum not null,  -- 認証方式のEnum型 (PASSWORD または OAUTH)
+    login_at timestamp,
+
+   -- grant_typeが'PASSWORD'の場合にのみemailかphone_numberのどちらかが必須
+    CHECK ((grant_type = 'PASSWORD' AND (email IS NOT NULL OR phone_number IS NOT NULL)) OR grant_type = 'OAUTH')
 );

--- a/migrate/migration_sql/000012_auth_providers.down.sql
+++ b/migrate/migration_sql/000012_auth_providers.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS auth_dogrun_managers CASCADE;

--- a/migrate/migration_sql/000012_auth_providers.down.sql
+++ b/migrate/migration_sql/000012_auth_providers.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS auth_dogrun_managers CASCADE;
+DROP TABLE IF EXISTS oauth_providers CASCADE;

--- a/migrate/migration_sql/000012_auth_providers.up.sql
+++ b/migrate/migration_sql/000012_auth_providers.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS oauth_providers (
+    oauth_id serial primary key,
+    auth_dog_owner_id bigint not null references auth_dog_owners(auth_dog_owner_id),  -- auth_dog_ownersへの外部キー
+    provider_name varchar(50) not null,  -- OAuthプロバイダ名（例: 'google', 'facebook' など）
+    provider_user_id varchar(255) not null,  -- OAuthプロバイダから提供されるユーザーID
+    token varchar(512),  -- アクセストークンやリフレッシュトークン（オプション）
+    token_expiration timestamp,  -- トークンの有効期限（オプション）
+    login_at timestamp  -- 最後のログイン時間
+);


### PR DESCRIPTION
## 概要
OAuthするにあたってのDB構成について

## 構成
- ユーザーがPassword認証の際は、電話番号かEmailのどちらかで認証するようにする。
  - 年齢層が高いとEmailより電話番号を優先して使用するため
- OAuth認証とPassword認証の両方をできるようにする
  - 年齢層が高いユーザーはどちらでやったか忘れることがあるため
- oauth_providersテーブルの作成
  - OAuthの情報用テーブル

## OAuthの大枠流れ
1. フロントエンドからのリクエスト
### Google OAuth認証の手順
- フロントエンドがGoogle OAuthの認証URL（Google提供）にリダイレクトし、ユーザーがGoogleにログイン。
- Googleが認証を完了した後、認証コードまたはアクセストークンをフロントエンドに返す。
- フロントエンドは、サーバーに対して以下のようなリクエストを送信
```
{
    "grant_type": "OAUTH",
    "provider_name": "google",
    "provider_user_id": "google_user_id_12345",
    "token": "access_token_from_google",
    "email": "user@gmail.com"
}
```

2. バックエンドでの処理
サーバー側でこのリクエストを受け取る。

ステップ1: dog_ownersテーブルの確認または登録
サーバーは、dog_ownersテーブルに、送信されたemail（例: user@gmail.com）が既に登録されているかどうかを確認

既存ユーザー: すでにdog_ownersに登録されている場合、そのユーザーのdog_owner_idを取得
新規ユーザー: dog_ownersにemailが存在しない場合は、新規レコードを作成してユーザーを登録

```
-- 既存のemailを確認
SELECT dog_owner_id FROM dog_owners WHERE email = 'user@gmail.com';

-- 新規の場合はdog_ownersにレコードを追加
INSERT INTO dog_owners (name, email, reg_at, upd_at) 
VALUES ('Google User', 'user@gmail.com', current_timestamp, current_timestamp) 
RETURNING dog_owner_id;
```

ステップ2: auth_dog_ownersテーブルにOAuth情報を登録
auth_dog_ownersテーブルに、このユーザーのOAuth認証情報を登録grant_type = 'OAUTH'であるため、emailやphone_numberのフィールドはNULLで問題ありません。
```
INSERT INTO auth_dog_owners (dog_owner_id, grant_type, login_at)
VALUES (dog_owner_id_from_previous_step, 'OAUTH', current_timestamp);
```

ステップ3: oauth_providersテーブルにGoogle OAuth情報を登録
Google OAuthで取得したprovider_name（例: google）、provider_user_id（GoogleからのユーザーID）、token（アクセストークン）をoauth_providersテーブルに登録
```
INSERT INTO oauth_providers (auth_dog_owner_id, provider_name, provider_user_id, token, token_expiration, login_at)
VALUES (
  auth_dog_owner_id_from_previous_step, 
  'google', 
  'google_user_id_12345', 
  'access_token_from_google', 
  current_timestamp + interval '1 hour', 
  current_timestamp
);
```

## 関連Issue

- 関連Issue: 
#58 
#51