### PR TITLE
ドッグラン検索画面の一覧用のレスポンスDTOの整理 

### DIFF
--- a/internal/dogrun/adapters/googleplace/field.go
+++ b/internal/dogrun/adapters/googleplace/field.go
@@ -29,20 +29,23 @@ const (
 	F_REGULAROPENINGHOURS_A = "regularOpeningHours" //営業時間
 	F_CURRENTOPENINGHOURS_A = "currentOpeningHours" //今日を含む７日間の営業日
 	F_WEBSITEURI_A          = "websiteUri"          //webサイトURL
-
+	//Preferred
+	F_EDITORIALSUMMARY_P = "editorialSummary" //場所の概要
 )
 
 // リクエストに使うfieldMaskたち
 var BASE_FILEDS = []string{
 	F_ID_IO,
-	F_SHORTFORMATTEDADDRESS_LO,
 	F_ADDRESSCOMPONENTS_LO,
+	F_SHORTFORMATTEDADDRESS_LO,
 	F_LOCATION_LO,
 	F_DISPLAYNAME_B,
 	F_RATING_B,
+	F_USERRATINGCOUNT_A,
 	F_BUSINESSSTATUS_B,
 	F_REGULAROPENINGHOURS_A,
 	F_WEBSITEURI_A,
+	F_EDITORIALSUMMARY_P,
 }
 
 type IFieldMask interface {

--- a/internal/dogrun/adapters/googleplace/resource.go
+++ b/internal/dogrun/adapters/googleplace/resource.go
@@ -19,8 +19,10 @@ type BaseResource struct {
 	AddressComponents     []AddressComponent `json:"addressComponents"`
 	DisplayName           LocalizedText      `json:"displayName"`
 	Rating                float32            `json:"rating"`
+	UserRatingCount       int                `json:"userRatingCount"`
 	BusinessStatus        string             `json:"businessStatus"`
 	OpeningHours          OpeningHours       `json:"regularOpeningHours"`
+	Summary               LocalizedText      `json:"editorialSummary"`
 }
 
 /*

--- a/internal/dogrun/core/dto/dogrun_res_dto.go
+++ b/internal/dogrun/core/dto/dogrun_res_dto.go
@@ -10,7 +10,7 @@ type DogrunDetailDto struct {
 	Name            string         `json:"name"`
 	Address         Address        `json:"address"`
 	Location        Location       `json:"location"`
-	BusinessStatus  string         `json:"businessStatus"`
+	BusinessStatus  string         `json:"businessStatus,omitempty"`
 	NowOpen         bool           `json:"nowOpen"`
 	BusinessHour    BusinessHour   `json:"businessHour"`
 	Description     string         `json:"description,omitempty"`
@@ -23,20 +23,18 @@ type DogrunDetailDto struct {
 
 // ドッグラン一覧での表示情報
 type DogrunListDto struct {
-	DogrunID        int            `json:"dogrunId,omitempty"`
-	PlaceId         string         `json:"placeId,omitempty"`
-	Name            string         `json:"name"`
-	Address         Address        `json:"address"`
-	Location        Location       `json:"location"`
-	NowOpen         bool           `json:"nowOpen"`
-	OpenTime        string         `json:"openTime"`
-	CloseTime       string         `json:"closeTime"`
-	Description     string         `json:"description,omitempty"`
-	GoogleRating    float32        `json:"googleRating,omitempty"`
-	UserRatingCount int            `json:"userRatingCount,omitempty"`
-	DogrunTags      []DogrunTagDto `json:"dogrunTags,omitempty"`
-	CreateAt        *time.Time     `json:"createAt,omitempty"`
-	UpdateAt        *time.Time     `json:"updateAt,omitempty"`
+	DogrunID          int             `json:"dogrunId,omitempty"`
+	PlaceId           string          `json:"placeId,omitempty"`
+	Name              string          `json:"name"`
+	Address           Address         `json:"address"`
+	Location          Location        `json:"location"`
+	BusinessStatus    string          `json:"businessStatus,omitempty"`
+	NowOpen           bool            `json:"nowOpen"`
+	ToadyBusinessHour DayBusinessTime `json:"toadyBusinessHour"`
+	Description       string          `json:"description,omitempty"`
+	GoogleRating      float32         `json:"googleRating,omitempty"`
+	UserRatingCount   int             `json:"userRatingCount,omitempty"`
+	DogrunTags        []DogrunTagDto  `json:"dogrunTags,omitempty"`
 }
 
 // 営業日情報


### PR DESCRIPTION
## 概要

一覧表示用のレスポンスDTOの整理

## 変更点
検索のレスポンスをDetaiのDTOで返してたので、一覧用のデータのDTOを作成し返す。

- ドッグラン検索のレスポンス内容
- 
## 影響範囲
ドッグラン検索

## テスト
基礎動作確認済み

## 関連Issue

- 関連Issue: #62
