### PR TITLE
googleの画像情報をレスポンスに追加

### DIFF
--- a/internal/dogrun/adapters/googleplace/field.go
+++ b/internal/dogrun/adapters/googleplace/field.go
@@ -24,6 +24,7 @@ const (
 	F_DISPLAYNAME_B    = "displayName"    // 表示名
 	F_RATING_B         = "rating"         //評価
 	F_BUSINESSSTATUS_B = "businessStatus" //評価(0~5)
+	F_PHOTOS_B         = "photos"         //画像
 	//Advanced
 	F_USERRATINGCOUNT_A     = "userRatingCount"     //評価数
 	F_REGULAROPENINGHOURS_A = "regularOpeningHours" //営業時間
@@ -46,6 +47,7 @@ var BASE_FILEDS = []string{
 	F_REGULAROPENINGHOURS_A,
 	F_WEBSITEURI_A,
 	F_EDITORIALSUMMARY_P,
+	F_PHOTOS_B,
 }
 
 type IFieldMask interface {

--- a/internal/dogrun/adapters/googleplace/resource.go
+++ b/internal/dogrun/adapters/googleplace/resource.go
@@ -23,6 +23,7 @@ type BaseResource struct {
 	BusinessStatus        string             `json:"businessStatus"`
 	OpeningHours          OpeningHours       `json:"regularOpeningHours"`
 	Summary               LocalizedText      `json:"editorialSummary"`
+	Photos                []PhotoObject      `json:"photos"`
 }
 
 /*
@@ -56,6 +57,13 @@ func (o *OpeningHours) IsNotEmpty() bool {
 type LocalizedText struct {
 	Text         string `json:"text"`
 	LanguageCode string `json:"languageCode"`
+}
+
+// google写真情報
+type PhotoObject struct {
+	Name     string `json:"name"`
+	WidthPx  uint   `json:"widthPx"`
+	HeightPx uint   `json:"heightPx"`
 }
 
 // 構造型住所

--- a/internal/dogrun/core/dto/dogrun_res_dto.go
+++ b/internal/dogrun/core/dto/dogrun_res_dto.go
@@ -35,6 +35,7 @@ type DogrunListDto struct {
 	GoogleRating      float32         `json:"googleRating,omitempty"`
 	UserRatingCount   int             `json:"userRatingCount,omitempty"`
 	DogrunTags        []DogrunTagDto  `json:"dogrunTags,omitempty"`
+	Photos            []PhotoInfo     `json:"photos,omitempty"`
 }
 
 // 営業日情報
@@ -65,6 +66,12 @@ type DayBusinessTime struct {
 type SpecialBusinessHour struct {
 	Date string `json:"date"`
 	DayBusinessTime
+}
+
+type PhotoInfo struct {
+	PhotoKey string `json:"photoKey"`
+	WidthPx  uint   `json:"widthPx"`
+	HeightPx uint   `json:"heightPx"`
 }
 
 // ドッグランタグ情報

--- a/internal/dogrun/core/handler/dogrun_handler.go
+++ b/internal/dogrun/core/handler/dogrun_handler.go
@@ -71,6 +71,44 @@ func (h *dogrunHandler) GetDogrunDetail(c echo.Context, placeID string) (*dto.Do
 	return &resDogDetail, nil
 }
 
+func (h *dogrunHandler) GetDogrunByID(id string) {
+	fmt.Println(h.drr.GetDogrunByID(id))
+}
+
+/*
+指定範囲内のドッグラン検索
+*/
+func (h *dogrunHandler) SearchAroundDogruns(c echo.Context, condition dto.SearchAroudRectangleCondition) ([]dto.DogrunListDto, error) {
+	logger := log.GetLogger(c).Sugar()
+	logger.Debugw("検索条件", "condition", condition)
+
+	payload := googleplace.ConvertReqToSearchTextPayload(condition)
+	// バリデータのインスタンス作成
+	validate := validator.New()
+	// カスタムバリデーションルールの登録
+	_ = validate.RegisterValidation("latitude", dto.VLatitude)
+	_ = validate.RegisterValidation("longitude", dto.VLongitude)
+
+	//base情報のFieldを使用
+	var baseFiled googleplace.IFieldMask = googleplace.BaseField{}
+
+	//place情報の取得
+	dogrunsG, err := h.searchTextUpToSpecifiedTimes(c, payload, baseFiled)
+	if err != nil {
+		return nil, err
+	}
+	logger.Infof("googleレスポンスplace数:%d", len(dogrunsG))
+
+	//DBにある指定場所内のドッグランを取得
+	dogrunsD, err := h.drr.GetDogrunByRectanglePointer(c, condition)
+	if err != nil {
+		return nil, err
+	}
+	logger.Infof("DBから取得数:%d", len(dogrunsD))
+
+	return trimAroundDogrunDetailInfo(dogrunsG, dogrunsD), nil
+}
+
 /*
 Google情報とDB情報から、ドッグラン詳細情報を作成
 基本的に、DB情報をドッグランマネージャーからの手動更新がある前提で、優先情報とする
@@ -372,44 +410,6 @@ func attachRegularBusinessTime(businessHours *dto.RegularBusinessHour, businessT
 	case 6:
 		businessHours.Saturday = businessTime
 	}
-}
-
-func (h *dogrunHandler) GetDogrunByID(id string) {
-	fmt.Println(h.drr.GetDogrunByID(id))
-}
-
-/*
-指定範囲内のドッグラン検索
-*/
-func (h *dogrunHandler) SearchAroundDogruns(c echo.Context, condition dto.SearchAroudRectangleCondition) ([]dto.DogrunListDto, error) {
-	logger := log.GetLogger(c).Sugar()
-	logger.Debugw("検索条件", "condition", condition)
-
-	payload := googleplace.ConvertReqToSearchTextPayload(condition)
-	// バリデータのインスタンス作成
-	validate := validator.New()
-	// カスタムバリデーションルールの登録
-	_ = validate.RegisterValidation("latitude", dto.VLatitude)
-	_ = validate.RegisterValidation("longitude", dto.VLongitude)
-
-	//base情報のFieldを使用
-	var baseFiled googleplace.IFieldMask = googleplace.BaseField{}
-
-	//place情報の取得
-	dogrunsG, err := h.searchTextUpToSpecifiedTimes(c, payload, baseFiled)
-	if err != nil {
-		return nil, err
-	}
-	logger.Infof("googleレスポンスplace数:%d", len(dogrunsG))
-
-	//DBにある指定場所内のドッグランを取得
-	dogrunsD, err := h.drr.GetDogrunByRectanglePointer(c, condition)
-	if err != nil {
-		return nil, err
-	}
-	logger.Infof("DBから取得数:%d", len(dogrunsD))
-
-	return trimAroundDogrunDetailInfo(dogrunsG, dogrunsD), nil
 }
 
 /*

--- a/internal/dogrun/core/handler/dogrun_handler.go
+++ b/internal/dogrun/core/handler/dogrun_handler.go
@@ -520,6 +520,7 @@ func resolveDogrunList(dogrunG googleplace.BaseResource, dogrunD model.Dogrun) d
 		Description:       util.ChooseStringValidValue(dogrunD.Description, dogrunG.Summary.Text),
 		GoogleRating:      dogrunG.Rating,
 		UserRatingCount:   dogrunG.UserRatingCount,
+		Photos:            resolvePlacePhotos(dogrunG),
 		DogrunTags:        resolveDogrunTagInfo(dogrunD), // ドッグランタグ情報
 	}
 
@@ -545,6 +546,7 @@ func resolveDogrunListByOnlyGoogle(dogrunG googleplace.BaseResource) dto.DogrunL
 		Description:       dogrunG.Summary.Text,
 		GoogleRating:      dogrunG.Rating,
 		UserRatingCount:   dogrunG.UserRatingCount,
+		Photos:            resolvePlacePhotos(dogrunG),
 	}
 
 }
@@ -607,4 +609,22 @@ func resolveTodayBusinessHour(dogrunG googleplace.BaseResource, dogrunD model.Do
 	}
 
 	return todaybusinessTimeD
+}
+
+/*
+googleの社員情報をレスポンスに整形
+*/
+func resolvePlacePhotos(dogrunG googleplace.BaseResource) []dto.PhotoInfo {
+	var photos []dto.PhotoInfo
+
+	for _, photo := range dogrunG.Photos {
+		photoInfo := dto.PhotoInfo{
+			PhotoKey: photo.Name,
+			HeightPx: photo.HeightPx,
+			WidthPx:  photo.WidthPx,
+		}
+		photos = append(photos, photoInfo)
+	}
+
+	return photos
 }


### PR DESCRIPTION
## 概要

googleの画像情報（最大10件）をドッグラン検索のレスポンスに追加する。
具体的な画像は、それ用のエンドポイントを作成し、画像取得（フロントで表示可能なURL）用のリクエストを作成予定

## 変更点

- ドッグラン検索のレスポンスに、photosを追加


## 影響範囲

ドッグラン検索

## テスト
なし

## 関連Issue

- 関連Issue: #62
