### PR TITLE
google画像取得用リクエストの作成

### DIFF
--- a/cmd/wanrun.go
+++ b/cmd/wanrun.go
@@ -75,6 +75,7 @@ func newRouter(e *echo.Echo, dbConn *gorm.DB) {
 	dogrun.GET("/detail/:placeId", dogrunConrtoller.GetDogrunDetail)
 	dogrun.GET("/:id", dogrunConrtoller.GetDogrun)
 	dogrun.POST("/search", dogrunConrtoller.SearchAroundDogruns)
+	dogrun.GET("/photo/src", dogrunConrtoller.GetDogrunPhoto)
 
 	authController := newAuth(dbConn)
 	auth := e.Group("auth")

--- a/internal/dogrun/adapters/googleplace/resource.go
+++ b/internal/dogrun/adapters/googleplace/resource.go
@@ -128,3 +128,9 @@ func (o *OpeningHoursPeriodInfo) FormatTime() string {
 	// "HH:mm" 形式で返す
 	return fmt.Sprintf("%s:%s:00", hh, mm)
 }
+
+// google places photo mediaのレスポンス
+type PhotoMediaResource struct {
+	Name     string `json:"name"`
+	PhotoUri string `json:"photoUri"`
+}

--- a/internal/dogrun/adapters/googleplace/url.go
+++ b/internal/dogrun/adapters/googleplace/url.go
@@ -1,23 +1,30 @@
 package googleplace
 
 const (
-	MAP_BASE    string = "https://maps.googleapis.com/maps/api/place"
-	PLACES_BASE string = "https://places.googleapis.com/v1/places"
+	// MAP_BASE    string = "https://maps.googleapis.com/maps/api/place"
+	PLACES_BASE        string = "https://places.googleapis.com/v1"
+	PLACES_BASE_PLACES string = PLACES_BASE + "/" + PLACES
 )
 
 const (
-	SEARCH_NEARBY = "searchNearby"
-	SEARCH_TEXT   = "searchText"
+	PLACES        string = "places"
+	SEARCH_NEARBY string = "searchNearby"
+	SEARCH_TEXT   string = "searchText"
+	MEDIA         string = "media"
 )
 
 func urlPlacesWPlaceId(placeeId string) string {
-	return PLACES_BASE + "/" + placeeId
+	return PLACES_BASE_PLACES + "/" + placeeId
 }
 
 func urlPlacesWSearchNearBy() string {
-	return PLACES_BASE + ":" + SEARCH_NEARBY
+	return PLACES_BASE_PLACES + ":" + SEARCH_NEARBY
 }
 
 func urlPlacesWSearchText() string {
-	return PLACES_BASE + ":" + SEARCH_TEXT
+	return PLACES_BASE_PLACES + ":" + SEARCH_TEXT
+}
+
+func urlPlacesPhotoWName(name string) string {
+	return PLACES_BASE + "/" + name + "/" + MEDIA
 }


### PR DESCRIPTION
## 概要
ドッグラン一覧検索のレスポンスの画像情報のnameを元にgoogleの画像URLを取得するリクエスト処理の作成

## 変更点

同上

## 影響範囲
新リクエスト作成

## テスト

なし

## 関連Issue

- 関連Issue: #62


## リクエスト方法
~/photo/src
クエリパラメーター
name : places/{placeId}/photos/{photoKey} （一覧検索結果の画像情報の`name`そのまま）
widthPx : 画像の幅（1以上4800以下。マックスサイズは一覧検索結果に乗っけてます）
heightPx : 画像の高さ（1以上4800以下。マックスサイズは一覧検索結果に乗っけてます）

