### PR TITLE
犬の登録・更新処理の追加

### DIFF
--- a/cmd/wanrun.go
+++ b/cmd/wanrun.go
@@ -67,8 +67,8 @@ func newRouter(e *echo.Echo, dbConn *gorm.DB) {
 	dog.GET("/all", dogController.GetAllDogs)
 	dog.GET("/detail/:dogID", dogController.GetDogByID)
 	dog.GET("/ownered/:dogOwnerId", dogController.GetDogByDogOwnerID)
-	dog.POST("/create", dogController.CreateDog)
-	dog.DELETE("/delete", dogController.DeleteDog)
+	dog.POST("", dogController.CreateDog)
+	dog.DELETE("", dogController.DeleteDog)
 	// dog.PUT("/:dogID", dogController.UpdateDog)
 
 	// dogrun関連

--- a/cmd/wanrun.go
+++ b/cmd/wanrun.go
@@ -68,6 +68,7 @@ func newRouter(e *echo.Echo, dbConn *gorm.DB) {
 	dog.GET("/detail/:dogID", dogController.GetDogByID)
 	dog.GET("/ownered/:dogOwnerId", dogController.GetDogByDogOwnerID)
 	dog.POST("", dogController.CreateDog)
+	dog.PUT("", dogController.UpdateDog)
 	dog.DELETE("", dogController.DeleteDog)
 	// dog.PUT("/:dogID", dogController.UpdateDog)
 

--- a/common/validation.go
+++ b/common/validation.go
@@ -1,0 +1,37 @@
+package common
+
+import "github.com/go-playground/validator/v10"
+
+// PKカスタムバリデーション（登録時）
+func VCreatePrimaryKey(fl validator.FieldLevel) bool {
+	pk := fl.Field().Int()
+	return pk == 0
+}
+
+// PKカスタムバリデーション（更新時）
+func VUpdatePrimaryKey(fl validator.FieldLevel) bool {
+	pk := fl.Field().Int()
+	return pk != 0
+}
+
+// 性別値
+const (
+	SEX_MALE   = "M"
+	SEX_FEMAIL = "F"
+	SEX_UNKNOW = "U"
+	SEX_OTHER  = "O"
+)
+
+var sex_values []string = []string{SEX_MALE, SEX_FEMAIL, SEX_UNKNOW, SEX_OTHER}
+
+// 性別のバリデーション
+func VSex(fl validator.FieldLevel) bool {
+	sex := fl.Field().String()
+
+	for _, v := range sex_values {
+		if v == sex {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dog/adapters/repository/dog_repository.go
+++ b/internal/dog/adapters/repository/dog_repository.go
@@ -12,7 +12,8 @@ type IDogRepository interface {
 	GetDogByID(int64) (model.Dog, error)
 	GetDogByDogOwnerID(int64) ([]model.Dog, error)
 	CreateDog(model.Dog) (model.Dog, error)
-	DeleteDog(int) error
+	UpdateDog(model.Dog) (model.Dog, error)
+	DeleteDog(int64) error
 }
 
 type dogRepository struct {
@@ -41,7 +42,7 @@ func (dr *dogRepository) GetAllDogs() ([]model.Dog, error) {
 //   - error:	エラー
 func (dr *dogRepository) GetDogByID(dogID int64) (model.Dog, error) {
 	dog := model.Dog{}
-	if err := dr.db.Preload("DogType").Where("dog_id=?", dogID).First(&dog).Error; err != nil {
+	if err := dr.db.Preload("DogType").Where("dog_id=?", dogID).Find(&dog).Error; err != nil {
 		return model.Dog{}, err
 	}
 	return dog, nil
@@ -78,7 +79,22 @@ func (dr *dogRepository) CreateDog(dog model.Dog) (model.Dog, error) {
 	return dog, nil
 }
 
-func (dr *dogRepository) DeleteDog(dogID int) error {
+// UpdateDog: dogのupdate
+//
+// args:
+//   - model.Dog:	更新するdog
+//
+// return:
+//   - model.Dog:	更新したdog
+//   - error:	エラー
+func (dr *dogRepository) UpdateDog(dog model.Dog) (model.Dog, error) {
+	if err := dr.db.Save(&dog).Error; err != nil {
+		return model.Dog{}, err
+	}
+	return dog, nil
+}
+
+func (dr *dogRepository) DeleteDog(dogID int64) error {
 	result := dr.db.Where("dog_id=?", dogID).Delete(&model.Dog{})
 
 	if result.Error != nil {

--- a/internal/dog/adapters/repository/dog_repository.go
+++ b/internal/dog/adapters/repository/dog_repository.go
@@ -11,7 +11,7 @@ type IDogRepository interface {
 	GetAllDogs() ([]model.Dog, error)
 	GetDogByID(int64) (model.Dog, error)
 	GetDogByDogOwnerID(int64) ([]model.Dog, error)
-	CreateDog() (model.Dog, error)
+	CreateDog(model.Dog) (model.Dog, error)
 	DeleteDog(int) error
 }
 
@@ -31,7 +31,7 @@ func (dr *dogRepository) GetAllDogs() ([]model.Dog, error) {
 	return dogs, nil
 }
 
-// GetDogByID: DogIDでdogsのセレクト。dogTypeもロードする
+// GetDogByID: DBへDogIDでdogsのセレクト。dogTypeもロードする
 //
 // args:
 //   - int64:	dogId
@@ -47,7 +47,7 @@ func (dr *dogRepository) GetDogByID(dogID int64) (model.Dog, error) {
 	return dog, nil
 }
 
-// GetDogByID: DogOwnerIDでdogsのセレクト。dogTypeもロードする
+// GetDogByID: DBへDogOwnerIDでdogsのセレクト。dogTypeもロードする
 //
 // args:
 //   - int:	dogId
@@ -63,8 +63,15 @@ func (dr *dogRepository) GetDogByDogOwnerID(dogOwnerID int64) ([]model.Dog, erro
 	return dogs, nil
 }
 
-func (dr *dogRepository) CreateDog() (model.Dog, error) {
-	dog := model.Dog{}
+// CreateDog: DBへdogのinsert
+//
+// args:
+//   - model.Dog:	登録するdog
+//
+// return:
+//   - model.dog:	登録されたdog
+//   - error:	エラー
+func (dr *dogRepository) CreateDog(dog model.Dog) (model.Dog, error) {
 	if err := dr.db.Create(&dog).Error; err != nil {
 		return model.Dog{}, err
 	}

--- a/internal/dog/core/dto/dog_req_dto.go
+++ b/internal/dog/core/dto/dog_req_dto.go
@@ -1,1 +1,12 @@
 package dto
+
+// dog詳細レスポンス
+type DogSaveReq struct {
+	DogID      int64  `json:"dogId" validate:"primaryKey"`
+	DogOwnerID int64  `json:"dogOwnerId" validate:"required"`
+	Name       string `json:"name" validate:"required"`
+	DogTypeID  int64  `json:"dogTypeId" validate:"required"`
+	Weight     int64  `json:"weight" validate:"required"`
+	Sex        string `json:"sex" validate:"required,sex"`
+	Image      string `json:"image"`
+}

--- a/internal/models/dog_model.go
+++ b/internal/models/dog_model.go
@@ -13,11 +13,16 @@ type Dog struct {
 	Sex        sql.NullString `gorm:"size:1;column:sex"`
 	Image      sql.NullString `gorm:"column:image"`
 	CreateAt   sql.NullTime   `gorm:"column:reg_at;not null;autoCreateTime"`
-	UpdateAt   sql.NullTime   `gorm:"column:upd_at;not null;autoCreateTime"`
+	UpdateAt   sql.NullTime   `gorm:"column:upd_at;not null;autoUpdateTime"`
 
 	//リレーション
 	DogOwner DogOwner   `gorm:"foreignKey:DogOwnerID;references:DogOwnerID"`
 	DogType  DogTypeMst `gorm:"foreignKey:DogTypeID;references:DogTypeID"`
+}
+
+// dogが空かの判定
+func (d *Dog) IsEmpty() bool {
+	return !d.DogID.Valid
 }
 
 type DogTypeMst struct {

--- a/internal/models/dogrun_model.go
+++ b/internal/models/dogrun_model.go
@@ -21,7 +21,7 @@ type Dogrun struct {
 	Longitude       sql.NullFloat64 `gorm:"column:longitude"`
 	Description     sql.NullString  `gorm:"type:text;column:description"`
 	CreateAt        sql.NullTime    `gorm:"column:reg_at;not null;autoCreateTime"`
-	UpdateAt        sql.NullTime    `gorm:"column:upd_at;not null;autoCreateTime"`
+	UpdateAt        sql.NullTime    `gorm:"column:upd_at;not null;autoUpdateTime"`
 
 	//リレーション
 	DogrunTags           []DogrunTag           `gorm:"foreignKey:DogrunID;references:DogrunID"`

--- a/pkg/errors/errcode.go
+++ b/pkg/errors/errcode.go
@@ -3,6 +3,7 @@ package errors
 import "fmt"
 
 const (
+	OTHER     int = 0
 	AUTH      int = 1
 	DOG       int = 2
 	DOG_OWNER int = 3
@@ -17,6 +18,13 @@ const (
 type eType struct {
 	service   int
 	errorType int
+}
+
+/*
+その他の予期せぬエラー
+*/
+func NewUnexpectedErrorEType() eType {
+	return eType{OTHER, SERVER}
 }
 
 /*

--- a/pkg/errors/message.go
+++ b/pkg/errors/message.go
@@ -1,5 +1,7 @@
 package errors
 
 const (
-	M_REQUEST_PARAM_MUST_BE_NATURAL = "[リクエストパラメータが不正]整数のみ指定可能です"
+	M_REQUEST_PARAM_MUST_BE_NATURAL  = "[リクエストパラメータが不正]整数のみ指定可能です"
+	M_REQUEST_BODY_IS_INVALID        = "リクエストボディが不正です"
+	M_REQUEST_BODY_VALIDATION_FAILED = "リクエストボディがバリデーションに違反しています"
 )

--- a/pkg/errors/message.go
+++ b/pkg/errors/message.go
@@ -1,6 +1,7 @@
 package errors
 
 const (
+	M_UNEXPECTED_ERROR               = "予期せぬエラー"
 	M_REQUEST_PARAM_MUST_BE_NATURAL  = "[リクエストパラメータが不正]整数のみ指定可能です"
 	M_REQUEST_BODY_IS_INVALID        = "リクエストボディが不正です"
 	M_REQUEST_BODY_VALIDATION_FAILED = "リクエストボディがバリデーションに違反しています"

--- a/pkg/errors/wrerror.go
+++ b/pkg/errors/wrerror.go
@@ -58,12 +58,14 @@ func NewWRError(err error, msg string, errorType eType) *wrError {
 カスタムエラーハンドラーミドルウェア
 */
 func HttpErrorHandler(err error, c echo.Context) {
-	code := 500
+	code := http.StatusInternalServerError
 
 	var me *wrError
 	if wreer, ok := err.(*wrError); ok {
 		me = wreer
 		code = mappingError(me)
+	} else {
+		me = NewWRError(err, M_UNEXPECTED_ERROR, NewUnexpectedErrorEType())
 	}
 
 	res := ErrorRes{


### PR DESCRIPTION
## 概要

犬の登録処理と更新処理の繋ぎ合わせと作成

## 変更点
- 登録処理を作り直し（POST:~/dog/create -> POST:~/dog)
- 更新処理の追加（PUT:~/dog)
- 削除処理にも犬の存在チェック

登録更新のボディ
``` :json
{
    "dogId" : 7,(登録なら0かnull)
    "dogOwnerId": 4,
    "name": "ポチ",
    "dogTypeId": 13,
    "weight": 15,
    "sex": "U",
    "image": "https://example.com/dog-image.jpg"
}
```

## 影響範囲
犬の登録と更新と削除

## テスト
なし

## 関連Issue
なし