### PR TITLE
ドッグラン検索の初期値を空に変更.変数名等の変更(#80)

### DIFF
--- a/internal/dogrun/adapters/googleplace/payload.go
+++ b/internal/dogrun/adapters/googleplace/payload.go
@@ -53,7 +53,7 @@ type rectangle struct {
 	High pointer `json:"high" validate:"required"` //長方形の北東の角
 }
 
-func ConvertReqToSearchNearbyPayload(req dto.SearchAroudCircleCondition) SearchNearbyPayLoad {
+func ConvertReqToSearchNearbyPayload(req dto.SearchAroundCircleCondition) SearchNearbyPayLoad {
 	center := pointer{
 		Latitude:  req.Center.Latitude,
 		Longitude: req.Center.Longitude,
@@ -72,7 +72,7 @@ func ConvertReqToSearchNearbyPayload(req dto.SearchAroudCircleCondition) SearchN
 	}
 }
 
-func ConvertReqToSearchTextPayload(req dto.SearchAroudRectangleCondition) SearchTextPayLoad {
+func ConvertReqToSearchTextPayload(req dto.SearchAroundRectangleCondition) SearchTextPayLoad {
 	rectangle := rectangle{
 		Low: pointer{
 			Latitude:  req.Target.Southwest.Latitude,

--- a/internal/dogrun/adapters/repository/dogrun_repository.go
+++ b/internal/dogrun/adapters/repository/dogrun_repository.go
@@ -13,7 +13,7 @@ import (
 type IDogrunRepository interface {
 	GetDogrunByPlaceID(echo.Context, string) (model.Dogrun, error)
 	GetDogrunByID(string) (model.Dogrun, error)
-	GetDogrunByRectanglePointer(echo.Context, dto.SearchAroudRectangleCondition) ([]model.Dogrun, error)
+	GetDogrunByRectanglePointer(echo.Context, dto.SearchAroundRectangleCondition) ([]model.Dogrun, error)
 	RegistDogrunPlaceId(echo.Context, string) (int, error)
 }
 
@@ -52,7 +52,7 @@ func (drr *dogrunRepository) GetDogrunByID(id string) (model.Dogrun, error) {
 /*
 リクエストのボディの条件に基づいて、指定範囲内のドッグランを取得する
 */
-func (drr *dogrunRepository) GetDogrunByRectanglePointer(c echo.Context, condition dto.SearchAroudRectangleCondition) ([]model.Dogrun, error) {
+func (drr *dogrunRepository) GetDogrunByRectanglePointer(c echo.Context, condition dto.SearchAroundRectangleCondition) ([]model.Dogrun, error) {
 	logger := log.GetLogger(c).Sugar()
 	dogruns := []model.Dogrun{}
 	if err := drr.db.Preload("DogrunTags.TagMst").

--- a/internal/dogrun/controller/dogrun_controller.go
+++ b/internal/dogrun/controller/dogrun_controller.go
@@ -52,7 +52,7 @@ func (dc *dogrunController) GetDogrun(c echo.Context) error {
 func (dc *dogrunController) SearchAroundDogruns(c echo.Context) error {
 	logger := log.GetLogger(c).Sugar()
 	//リクエストボディをバインド
-	var condition dto.SearchAroudRectangleCondition
+	var condition dto.SearchAroundRectangleCondition
 	if err := c.Bind(&condition); err != nil {
 		err = errors.NewWRError(err, "検索条件が不正です", errors.NewDogrunClientErrorEType())
 		logger.Error(err)

--- a/internal/dogrun/core/dto/dogrun_req_dto.go
+++ b/internal/dogrun/core/dto/dogrun_req_dto.go
@@ -3,7 +3,7 @@ package dto
 /*
 円型検索のリクエストボディ
 */
-type SearchAroudCircleCondition struct {
+type SearchAroundCircleCondition struct {
 	Center pointer      `json:"center" validate:"required"`
 	Target centerTarget `json:"target" validate:"required"`
 }
@@ -27,7 +27,7 @@ type centerTarget struct {
 /*
 長方形型検索のリクエストボディ
 */
-type SearchAroudRectangleCondition struct {
+type SearchAroundRectangleCondition struct {
 	Target rectangleTarget `json:"target" validate:"required"`
 }
 

--- a/internal/dogrun/core/dto/dogrun_res_dto.go
+++ b/internal/dogrun/core/dto/dogrun_res_dto.go
@@ -3,7 +3,7 @@ package dto
 import "time"
 
 // ドッグラン詳細画面での表示情報
-type DogrunDetails struct {
+type DogrunDetail struct {
 	DogrunID        int            `json:"dogrunId,omitempty"`
 	DogrunManagerID int            `json:"dogrunManagerId,omitempty"`
 	PlaceId         string         `json:"placeId,omitempty"`

--- a/internal/dogrun/core/dto/dogrun_res_dto.go
+++ b/internal/dogrun/core/dto/dogrun_res_dto.go
@@ -3,7 +3,7 @@ package dto
 import "time"
 
 // ドッグラン詳細画面での表示情報
-type DogrunDetailDto struct {
+type DogrunDetails struct {
 	DogrunID        int            `json:"dogrunId,omitempty"`
 	DogrunManagerID int            `json:"dogrunManagerId,omitempty"`
 	PlaceId         string         `json:"placeId,omitempty"`
@@ -22,7 +22,7 @@ type DogrunDetailDto struct {
 }
 
 // ドッグラン一覧での表示情報
-type DogrunListDto struct {
+type DogrunLists struct {
 	DogrunID          int             `json:"dogrunId,omitempty"`
 	PlaceId           string          `json:"placeId,omitempty"`
 	Name              string          `json:"name"`

--- a/internal/dogrun/core/handler/dogrun_handler.go
+++ b/internal/dogrun/core/handler/dogrun_handler.go
@@ -22,9 +22,9 @@ const (
 )
 
 type IDogrunHandler interface {
-	GetDogrunDetail(echo.Context, string) (*dto.DogrunDetailDto, error)
+	GetDogrunDetail(echo.Context, string) (*dto.DogrunDetails, error)
 	GetDogrunByID(string)
-	SearchAroundDogruns(echo.Context, dto.SearchAroudRectangleCondition) ([]dto.DogrunListDto, error)
+	SearchAroundDogruns(echo.Context, dto.SearchAroudRectangleCondition) ([]dto.DogrunLists, error)
 	GetDogrunPhotoSrc(echo.Context, string, string, string) (string, error)
 }
 
@@ -37,7 +37,16 @@ func NewDogrunHandler(rest googleplace.IRest, drr repository.IDogrunRepository) 
 	return &dogrunHandler{rest, drr}
 }
 
-func (h *dogrunHandler) GetDogrunDetail(c echo.Context, placeID string) (*dto.DogrunDetailDto, error) {
+// GetDogRunDetailByPlaceId: placeIdでgoogle検索して返す
+//
+// args:
+//   - echo.Context:	コンテキスト
+//   - string:	placeID
+//
+// return:
+//   - dto.DogrunDetails:	詳細DTO
+//   - error:	エラー
+func (h *dogrunHandler) GetDogrunDetail(c echo.Context, placeID string) (*dto.DogrunDetails, error) {
 	logger := log.GetLogger(c).Sugar()
 	//base情報のFieldを使用
 	var baseFiled googleplace.IFieldMask = googleplace.BaseField{}
@@ -76,10 +85,16 @@ func (h *dogrunHandler) GetDogrunByID(id string) {
 	fmt.Println(h.drr.GetDogrunByID(id))
 }
 
-/*
-指定範囲内のドッグラン検索
-*/
-func (h *dogrunHandler) SearchAroundDogruns(c echo.Context, condition dto.SearchAroudRectangleCondition) ([]dto.DogrunListDto, error) {
+// SearchAroundDogruns: 指定内（長方形）のドッグランを検索、DB情報と照合して返す
+//
+// args:
+//   - echo.Context:	コンテキスト
+//   - dto.SearchAroundRectangleCondition:	指定場所条件
+//
+// return:
+//   - []dto.DogrunLists:	リストDTO
+//   - error:	エラー
+func (h *dogrunHandler) SearchAroundDogruns(c echo.Context, condition dto.SearchAroudRectangleCondition) ([]dto.DogrunLists, error) {
 	logger := log.GetLogger(c).Sugar()
 	logger.Debugw("検索条件", "condition", condition)
 
@@ -145,7 +160,7 @@ func (h *dogrunHandler) GetDogrunPhotoSrc(c echo.Context, name, widthPx, heightP
 Google情報とDB情報から、ドッグラン詳細情報を作成
 基本的に、DB情報をドッグランマネージャーからの手動更新がある前提で、優先情報とする
 */
-func resolveDogrunDetail(dogrunG googleplace.BaseResource, dogrunD model.Dogrun) dto.DogrunDetailDto {
+func resolveDogrunDetail(dogrunG googleplace.BaseResource, dogrunD model.Dogrun) dto.DogrunDetails {
 
 	if dogrunD.IsEmpty() && dogrunG.IsNotEmpty() {
 		return resolveDogrunDetailByOnlyGoogle(dogrunG)
@@ -158,7 +173,7 @@ func resolveDogrunDetail(dogrunG googleplace.BaseResource, dogrunD model.Dogrun)
 		dogrunManager = int(dogrunD.DogrunManagerID.Int64)
 	}
 
-	return dto.DogrunDetailDto{
+	return dto.DogrunDetails{
 		DogrunID:        int(dogrunD.DogrunID.Int64),
 		DogrunManagerID: dogrunManager,
 		PlaceId:         dogrunG.ID,
@@ -187,9 +202,9 @@ func resolveDogrunDetail(dogrunG googleplace.BaseResource, dogrunD model.Dogrun)
 /*
 DBにデータがない場合、google情報のみでドッグラン詳細情報を作成する
 */
-func resolveDogrunDetailByOnlyGoogle(dogrunG googleplace.BaseResource) dto.DogrunDetailDto {
+func resolveDogrunDetailByOnlyGoogle(dogrunG googleplace.BaseResource) dto.DogrunDetails {
 	var emptyDogrunD model.Dogrun
-	return dto.DogrunDetailDto{
+	return dto.DogrunDetails{
 		PlaceId: dogrunG.ID,
 		Name:    dogrunG.DisplayName.Text,
 		Address: resolveDogrunAddress(dogrunG, emptyDogrunD),
@@ -209,11 +224,11 @@ func resolveDogrunDetailByOnlyGoogle(dogrunG googleplace.BaseResource) dto.Dogru
 	}
 }
 
-func resolveDogrunDetailByOnlyDB(dogrunD model.Dogrun) dto.DogrunDetailDto {
+func resolveDogrunDetailByOnlyDB(dogrunD model.Dogrun) dto.DogrunDetails {
 
 	var emptyDogrunG googleplace.BaseResource
 
-	return dto.DogrunDetailDto{
+	return dto.DogrunDetails{
 		DogrunID:        int(dogrunD.DogrunID.Int64),
 		DogrunManagerID: int(dogrunD.DogrunManagerID.Int64),
 		PlaceId:         dogrunD.PlaceId.String,
@@ -485,7 +500,7 @@ func (h *dogrunHandler) searchTextUpToSpecifiedTimes(c echo.Context, payload goo
 検索結果をもとに、レスポンス用のDTOを作成
 placeIdで、両方にあるデータと、DBにのみあるデータ等で分ける
 */
-func (h *dogrunHandler) trimAroundDogrunDetailInfo(c echo.Context, dogrunsG []googleplace.BaseResource, dogrunsD []model.Dogrun) ([]dto.DogrunListDto, error) {
+func (h *dogrunHandler) trimAroundDogrunDetailInfo(c echo.Context, dogrunsG []googleplace.BaseResource, dogrunsD []model.Dogrun) ([]dto.DogrunLists, error) {
 	//google情報からpalceIdをkeyにmapにまとめる
 	dogrunsGWithPlaceID := make(map[string]googleplace.BaseResource, len(dogrunsG))
 	for _, dogrunG := range dogrunsG {
@@ -504,14 +519,14 @@ func (h *dogrunHandler) trimAroundDogrunDetailInfo(c echo.Context, dogrunsG []go
 		}
 	}
 
-	var dogrunDetailInfos []dto.DogrunListDto
+	dogrunLists := []dto.DogrunLists{}
 
 	//両方にplaceIdがある情報をDTOにつめる
 	for placeId, dogrunGValue := range dogrunsGWithPlaceID {
 		dogrunDValue, existDogrunD := dogrunsDWithPalceID[placeId]
 		if existDogrunD {
 			//DBにもある場合、両方からデータの選別
-			dogrunDetailInfos = append(dogrunDetailInfos, resolveDogrunList(dogrunGValue, dogrunDValue))
+			dogrunLists = append(dogrunLists, resolveDogrunList(dogrunGValue, dogrunDValue))
 			//DogrunsDから削除
 			delete(dogrunsDWithPalceID, placeId)
 		} else {
@@ -524,29 +539,29 @@ func (h *dogrunHandler) trimAroundDogrunDetailInfo(c echo.Context, dogrunsG []go
 			//レスポンス整形
 			dogrunGDetailInfo := resolveDogrunListByOnlyGoogle(dogrunGValue)
 			dogrunGDetailInfo.DogrunID = dogrunID
-			dogrunDetailInfos = append(dogrunDetailInfos, dogrunGDetailInfo)
+			dogrunLists = append(dogrunLists, dogrunGDetailInfo)
 		}
 	}
 
 	//placeIdはあるが、google側にないものをDTOにつめる
 	for _, dogrunDValue := range dogrunsDWithPalceID {
-		dogrunDetailInfos = append(dogrunDetailInfos, resolveDogrunListByOnlyDB(dogrunDValue))
+		dogrunLists = append(dogrunLists, resolveDogrunListByOnlyDB(dogrunDValue))
 	}
 
 	//placeIdがないDBのみのデータをDTOにつめる
 	for _, dogrunDValue := range dogrunDWithoutPlaceIdS {
-		dogrunDetailInfos = append(dogrunDetailInfos, resolveDogrunListByOnlyDB(dogrunDValue))
+		dogrunLists = append(dogrunLists, resolveDogrunListByOnlyDB(dogrunDValue))
 	}
 
-	return dogrunDetailInfos, nil
+	return dogrunLists, nil
 }
 
 /*
 Google情報とDB情報から、ドッグラン一覧情報を作成
 基本的に、DB情報をドッグランマネージャーからの手動更新がある前提で、優先情報とする
 */
-func resolveDogrunList(dogrunG googleplace.BaseResource, dogrunD model.Dogrun) dto.DogrunListDto {
-	return dto.DogrunListDto{
+func resolveDogrunList(dogrunG googleplace.BaseResource, dogrunD model.Dogrun) dto.DogrunLists {
+	return dto.DogrunLists{
 		DogrunID: int(dogrunD.DogrunID.Int64),
 		PlaceId:  dogrunG.ID,
 		Name:     util.ChooseStringValidValue(dogrunD.Name, dogrunG.DisplayName.Text),
@@ -570,10 +585,10 @@ func resolveDogrunList(dogrunG googleplace.BaseResource, dogrunD model.Dogrun) d
 /*
 DBにデータがない場合、google情報のみでドッグラン一覧情報を作成する
 */
-func resolveDogrunListByOnlyGoogle(dogrunG googleplace.BaseResource) dto.DogrunListDto {
+func resolveDogrunListByOnlyGoogle(dogrunG googleplace.BaseResource) dto.DogrunLists {
 	var emptyDogrunD model.Dogrun
 
-	return dto.DogrunListDto{
+	return dto.DogrunLists{
 		PlaceId: dogrunG.ID,
 		Name:    dogrunG.DisplayName.Text,
 		Address: resolveDogrunAddress(dogrunG, emptyDogrunD),
@@ -595,9 +610,9 @@ func resolveDogrunListByOnlyGoogle(dogrunG googleplace.BaseResource) dto.DogrunL
 /*
 google側にデータがない場合、DB情報のみでドッグラン一覧情報を作成する
 */
-func resolveDogrunListByOnlyDB(dogrunD model.Dogrun) dto.DogrunListDto {
+func resolveDogrunListByOnlyDB(dogrunD model.Dogrun) dto.DogrunLists {
 	var emptyDogrunG googleplace.BaseResource
-	return dto.DogrunListDto{
+	return dto.DogrunLists{
 		DogrunID: int(dogrunD.DogrunID.Int64),
 		Name:     dogrunD.Name.String,
 		Address:  resolveDogrunAddress(emptyDogrunG, dogrunD),

--- a/internal/models/dogrun_model.go
+++ b/internal/models/dogrun_model.go
@@ -88,7 +88,7 @@ func (d *Dogrun) IsSpecialBusinessHoursNotEmpty() bool {
 /*
 対象のドッグランの通常営業時時間データから、指定されたの曜日(数値:0~6)の営業時間データを返す
 */
-func (d *Dogrun) FetchTargetRegularBussinessHour(day int) RegularBusinessHour {
+func (d *Dogrun) FetchTargetRegularBusinessHour(day int) RegularBusinessHour {
 	for _, v := range d.RegularBusinessHours {
 		if day == int(v.Day.Int64) {
 			return v


### PR DESCRIPTION
## 概要

ドッグランの検索が0件の時のレスポンスをから配列になるように修正

## 変更点

- ドッグランの検索0件時のレスポンス

## 影響範囲

ドッグラン検索
## テスト

なし

## 関連Issue

- 関連Issue: #80
