### PR TITLE
create: revoke processing

### DIFF
--- a/cmd/wanrun.go
+++ b/cmd/wanrun.go
@@ -30,10 +30,6 @@ func init() {
 
 }
 
-const (
-	AUTH_GROUP_PATH string = "/auth"
-)
-
 func Main() {
 	dbConn, err := db.NewDB()
 	if err != nil {
@@ -57,7 +53,7 @@ func Main() {
 
 	// JWTミドルウェアの設定
 	authMiddleware := newAuthMiddleware(dbConn)
-	e.Use(authMiddleware.NewJwtValidationMiddleware(AUTH_GROUP_PATH))
+	e.Use(authMiddleware.NewJwtValidationMiddleware())
 
 	// CORSの設定
 	e.Use(middleware.CORS())
@@ -93,10 +89,11 @@ func newRouter(e *echo.Echo, dbConn *gorm.DB) {
 
 	// auth関連
 	authController := newAuth(dbConn)
-	auth := e.Group(AUTH_GROUP_PATH)
+	auth := e.Group("auth")
 	// auth.GET("/google/oauth", authController.GoogleOAuth)
 	auth.POST("/signUp", authController.SignUp)
 	auth.POST("/token", authController.LogIn)
+	auth.POST("/revoke", authController.Revoke)
 }
 
 // dogの初期化

--- a/internal/auth/adapters/repository/auth_repository.go
+++ b/internal/auth/adapters/repository/auth_repository.go
@@ -19,6 +19,7 @@ type IAuthRepository interface {
 	// CreateOAuthDogOwner(c echo.Context, dogOwnerCredential *model.DogOwnerCredential) (*model.DogOwnerCredential, error)
 	UpdateJwtID(c echo.Context, doc *model.DogOwnerCredential, jwt_id string) error
 	GetJwtID(c echo.Context, doi int64) (string, error)
+	DeleteJwtID(c echo.Context, doID int64) error
 }
 
 type authRepository struct {
@@ -244,6 +245,35 @@ func (ar *authRepository) UpdateJwtID(c echo.Context, doc *model.DogOwnerCredent
 			wrErrors.NewDogownerServerErrorEType())
 
 		logger.Errorf("Failed to update JWT ID: %v", wrErr)
+
+		return wrErr
+	}
+
+	return err
+}
+
+// DeleteJwtID: 対象のdogOwnerのjwt_idの削除
+//
+// args:
+//   - echo.Context: Echoのコンテキスト。リクエストやレスポンスにアクセスするために使用
+//   - dto.DogOwnerDTO: dogOwnerの情報
+//
+// return:
+//   - error: error情報
+func (ar *authRepository) DeleteJwtID(c echo.Context, doID int64) error {
+	logger := log.GetLogger(c).Sugar()
+
+	// 対象のdogOwnerのjwt_idの更新
+	err := ar.db.Model(&model.AuthDogOwner{}).
+		Where("dog_owner_id= ?", doID).
+		Update("jwt_id", nil).Error
+	if err != nil {
+		wrErr := wrErrors.NewWRError(
+			err,
+			"DBへの同期が失敗しました。",
+			wrErrors.NewDogownerServerErrorEType())
+
+		logger.Errorf("Failed to delete JWT ID: %v", wrErr)
 
 		return wrErr
 	}

--- a/internal/auth/controller/auth_controller.go
+++ b/internal/auth/controller/auth_controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/wanrun-develop/wanrun/internal/auth/core/dto"
 	"github.com/wanrun-develop/wanrun/internal/auth/core/handler"
+	"github.com/wanrun-develop/wanrun/internal/wrcontext"
 	"github.com/wanrun-develop/wanrun/pkg/errors"
 	"github.com/wanrun-develop/wanrun/pkg/log"
 )
@@ -15,7 +16,7 @@ import (
 type IAuthController interface {
 	SignUp(c echo.Context) error
 	LogIn(c echo.Context) error
-	LogOut(c echo.Context) error
+	Revoke(c echo.Context) error
 	// GoogleOAuth(c echo.Context) error
 }
 
@@ -147,7 +148,27 @@ func (ac *authController) LogIn(c echo.Context) error {
 	})
 }
 
-func (ac *authController) LogOut(c echo.Context) error { return nil }
+// Revoke: revoke機能
+//
+// args:
+//   - echo.Context: c Echoのコンテキスト。リクエストやレスポンスにアクセスするために使用されます。
+//
+// return:
+//   - error: error情報
+func (ac *authController) Revoke(c echo.Context) error {
+	// claims情報の取得
+	claims, wrErr := wrcontext.GetVerifiedClaims(c)
+
+	if wrErr != nil {
+		return wrErr
+	}
+
+	if wrErr := ac.ah.Revoke(c, claims); wrErr != nil {
+		return wrErr
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{})
+}
 
 // /*
 // OAuthのクエリパラメータのバリデーション

--- a/internal/auth/middleware/jwt.go
+++ b/internal/auth/middleware/jwt.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -17,7 +16,7 @@ import (
 )
 
 type IAuthJwt interface {
-	NewJwtValidationMiddleware(agp string) echo.MiddlewareFunc
+	NewJwtValidationMiddleware() echo.MiddlewareFunc
 }
 
 type authJwt struct {
@@ -40,7 +39,7 @@ const (
 //
 // return:
 //   - echo.MiddlewareFunc: JWT検証のためのミドルウェア設定
-func (aj *authJwt) NewJwtValidationMiddleware(agp string) echo.MiddlewareFunc {
+func (aj *authJwt) NewJwtValidationMiddleware() echo.MiddlewareFunc {
 	return echojwt.WithConfig(
 		echojwt.Config{
 			SigningKey: []byte(configs.FetchConfigStr("jwt.os.secret.key")), // 署名用の秘密鍵
@@ -49,9 +48,9 @@ func (aj *authJwt) NewJwtValidationMiddleware(agp string) echo.MiddlewareFunc {
 			},
 			TokenLookup: TOKEN_LOOK_UP, // トークンの取得場所
 			ContextKey:  CONTEXT_KEY,   // カスタムキーを設定
-			Skipper: func(c echo.Context) bool {
-				// authグループ配下のすべてのルートをスキップする
-				return strings.HasPrefix(c.Path(), agp)
+			Skipper: func(c echo.Context) bool { // スキップするパスを指定
+				path := c.Path()
+				return path == "/auth/token" || path == "/auth/signUp"
 			},
 			SuccessHandler: func(c echo.Context) {
 				// contextからJWTのclaims取得と検証

--- a/internal/test.go
+++ b/internal/test.go
@@ -19,11 +19,17 @@ func Test(c echo.Context) error {
 		return wrErr
 	}
 
-	userID := claims.ID
+	// dogOwnerIDの取得
+	dogOwnerID, wrErr := claims.GetDogOwnerIDAsInt64(c)
+	if wrErr != nil {
+		return wrErr
+	}
+	// jti情報
 	jti := claims.JTI
+	// 有効期限
 	exp := claims.ExpiresAt
 
-	logger.Infof("userID: %v, jti: %v, exp: %v\n", userID, jti, exp)
+	logger.Infof("userID: %v, jti: %v, exp: %v\n", dogOwnerID, jti, exp)
 
 	logger.Info("Test*()の実行. ")
 	if err := testError(); err != nil {


### PR DESCRIPTION
## 概要
revoke機能の実装
ミドルウェアのパスをハードコーディング指定に変更

## 変更点
- rovoke機能の実装
- ミドルウェアのスキップパスを`/auth`ではなくて、直接指定に変更
  - revokeが対象外のため

## 影響範囲
ミドルウェア設定

## 関連Issue
- 関連Issue: #97 #91