### PR TITLE
ドッグランへの入退場記録処理の作成

### DIFF
--- a/cmd/wanrun.go
+++ b/cmd/wanrun.go
@@ -151,6 +151,7 @@ func newRouter(e *echo.Echo, dbConn *gorm.DB) {
 
 	access := e.Group("access")
 	access.POST("/checkin", interactionController.CheckinDogrun)
+	access.DELETE("/checkout", interactionController.CheckoutDogrun)
 
 	// cms関連
 	cmsController := newCms(dbConn)

--- a/cmd/wanrun.go
+++ b/cmd/wanrun.go
@@ -150,6 +150,7 @@ func newRouter(e *echo.Echo, dbConn *gorm.DB) {
 	bookmark.DELETE("/dogrun", interactionController.DeleteBookmarks)
 
 	access := e.Group("access")
+	access.GET("/today/checkins", interactionController.GetTodayCheckins)
 	access.POST("/checkin", interactionController.CheckinDogrun)
 	access.DELETE("/checkout", interactionController.CheckoutDogrun)
 

--- a/internal/auth/core/dto/auth_user_info_dto.go
+++ b/internal/auth/core/dto/auth_user_info_dto.go
@@ -3,5 +3,5 @@ package dto
 type UserAuthInfoDTO struct {
 	UserID int64
 	JwtID  string
-	RoleID int64
+	RoleID int
 }

--- a/internal/auth/core/handler/auth_handler.go
+++ b/internal/auth/core/handler/auth_handler.go
@@ -38,14 +38,14 @@ func NewAuthHandler(ar repository.IAuthRepository) IAuthHandler {
 type AccountClaims struct {
 	ID   string `json:"id"`
 	JTI  string `json:"jti"`
-	Role int64  `json:"role"`
+	Role int    `json:"role"`
 	jwt.RegisteredClaims
 }
 
 const (
-	DOGRUNMG_ROLE       = 1
-	DOGRUNMG_ADMIN_ROLE = 2
-	DOGOWNER_ROLE       = 3
+	DOGRUNMG_ROLE       int = 1
+	DOGRUNMG_ADMIN_ROLE int = 2
+	DOGOWNER_ROLE       int = 3
 )
 
 // GetDogOwnerIDAsInt64: 共通処理で、int64のDogOwnerのID取得。

--- a/internal/auth/middleware/jwt.go
+++ b/internal/auth/middleware/jwt.go
@@ -167,7 +167,7 @@ func (aj *authJwt) jwtIDValid(c echo.Context, ac *handler.AccountClaims) error {
 	}
 
 	// Roleによる設定分岐
-	getJwtID := func(role int64, id int64) (string, error) {
+	getJwtID := func(role int, id int64) (string, error) {
 		switch role {
 		// dogowner
 		case handler.DOGOWNER_ROLE:

--- a/internal/dog/facade/dog_facade.go
+++ b/internal/dog/facade/dog_facade.go
@@ -1,0 +1,62 @@
+package facade
+
+import (
+	"fmt"
+
+	"github.com/labstack/echo/v4"
+	"github.com/wanrun-develop/wanrun/internal/dog/adapters/repository"
+	"github.com/wanrun-develop/wanrun/internal/wrcontext"
+	"github.com/wanrun-develop/wanrun/pkg/errors"
+	"github.com/wanrun-develop/wanrun/pkg/log"
+)
+
+type IDogFacade interface {
+	CheckDogownerValid(echo.Context, []int64) error
+}
+
+type dogFacade struct {
+	dr repository.IDogRepository
+}
+
+func NewDogFacade(drr repository.IDogRepository) IDogFacade {
+	return &dogFacade{drr}
+}
+
+// CheckDogownerValid: dogのdogownerが正しいかチェック
+// ログインユーザーのdogであるかをチェック
+//
+// args:
+//   - echo.Context:	コンテキスト
+//   - []]nt64:	dogIDs チェック対象のdogIDs
+//
+// return:
+// error:	エラー
+func (f dogFacade) CheckDogownerValid(c echo.Context, paramDogIDs []int64) error {
+	logger := log.GetLogger(c).Sugar()
+
+	// ログインユーザーIDの取得
+	userID, err := wrcontext.GetLoginUserID(c)
+	if err != nil {
+		return err
+	}
+	//ユーザーIDを条件にdog取得
+	dogsResults, err := f.dr.GetDogByDogOwnerID(c, userID)
+	if err != nil {
+		return err
+	}
+	//チェック用一時map
+	dogMap := make(map[int64]struct{})
+	for _, dog := range dogsResults {
+		dogMap[dog.DogID.Int64] = struct{}{}
+	}
+
+	for _, paramDogID := range paramDogIDs {
+		if _, exists := dogMap[paramDogID]; !exists {
+			err := errors.NewWRError(nil, fmt.Sprintf("指定されたドッグID:%dはあなたのペットではありません", paramDogID), errors.NewInteractionClientErrorEType())
+			logger.Error(err, "不正なdogIdの指定")
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/interaction/adapters/repository/interaction_repository.go
+++ b/internal/interaction/adapters/repository/interaction_repository.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"time"
+
 	"github.com/labstack/echo/v4"
 	model "github.com/wanrun-develop/wanrun/internal/models"
 	"github.com/wanrun-develop/wanrun/pkg/errors"
@@ -121,4 +123,70 @@ func (r *bookmarkRepository) DeleteBookmark(c echo.Context, dogrunIDs []int64, d
 		return err
 	}
 	return nil
+}
+
+type ICheckInOutRepository interface {
+	FindDogrunCheckin(echo.Context, int64, int64) (model.DogrunCheckin, error)
+	SaveDogrunCheckins(echo.Context, []model.DogrunCheckin) ([]model.DogrunCheckin, error)
+}
+
+type checkInOutRepository struct {
+	db *gorm.DB
+}
+
+func NewCheckInOutRepository(db *gorm.DB) ICheckInOutRepository {
+	return &checkInOutRepository{db}
+}
+
+// FindDogrunCheckin: dogIDとdogownerIDでcheckinへ検索
+//
+//	今日分ですでにチェックインしているかどうか
+//
+// args:
+//   - echo.Context:	コンテキスト
+//   - int64:	dogIDで条件指定
+//   - int64:	dogownerIDで条件指定
+//
+// return:
+//   - model.DogrunCheckin:	検索結果構造体
+//   - error:	エラー
+func (r *checkInOutRepository) FindDogrunCheckin(c echo.Context, dogrunID int64, dogID int64) (model.DogrunCheckin, error) {
+	logger := log.GetLogger(c).Sugar()
+
+	startOfDay := time.Now().Truncate(24 * time.Hour)
+	endOfDay := startOfDay.Add(24 * time.Hour)
+
+	checkin := model.DogrunCheckin{}
+	if err := r.db.
+		Where("dogrun_id = ?", dogrunID).
+		Where("dog_id = ?", dogID).
+		Where("checkin_at >= ? AND checkin_at < ?", startOfDay, endOfDay).
+		Find(&checkin).Error; err != nil {
+		logger.Error(err)
+		err := errors.NewWRError(err, "dogrun_checkinの検索に失敗しました。", errors.NewInteractionServerErrorEType())
+		return checkin, err
+	}
+
+	return checkin, nil
+}
+
+// SaveDogrunCheckins: dogrunCheckinの一括保存
+//
+// args:
+//   - echo.Context:	コンテキスト
+//   - []model.DogrunCheckin:	保存対象dogrunCheckin構造体スライス
+//
+// return:
+//   - []model.DogrunCheckin:	保存結果DogrunCheckins構造体スライス
+//   - error:	エラー
+func (r *checkInOutRepository) SaveDogrunCheckins(c echo.Context, checkins []model.DogrunCheckin) ([]model.DogrunCheckin, error) {
+	logger := log.GetLogger(c).Sugar()
+
+	if err := r.db.Save(&checkins).Error; err != nil {
+		logger.Error(err)
+		err := errors.NewWRError(err, "dogrun_checkinの保存に失敗しました。", errors.NewInteractionServerErrorEType())
+		return nil, err
+	}
+
+	return checkins, nil
 }

--- a/internal/interaction/controller/interaction_controller.go
+++ b/internal/interaction/controller/interaction_controller.go
@@ -17,6 +17,7 @@ type IInteractionController interface {
 	DeleteBookmarks(echo.Context) error
 	CheckinDogrun(echo.Context) error
 	CheckoutDogrun(echo.Context) error
+	GetTodayCheckins(echo.Context) error
 }
 
 type interactionController struct {
@@ -138,7 +139,7 @@ func (ic *interactionController) CheckinDogrun(c echo.Context) error {
 //   - echo.Context:	コンテキスト
 //
 // return:
-// error:	　エラー
+// error:	エラー
 func (ic *interactionController) CheckoutDogrun(c echo.Context) error {
 	logger := log.GetLogger(c).Sugar()
 
@@ -161,5 +162,20 @@ func (ic *interactionController) CheckoutDogrun(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return c.NoContent(http.StatusCreated)
+	return c.NoContent(http.StatusOK)
+}
+
+// GetTodayCheckins: すべての所有dogの今日のチェックイン履歴の取得
+//
+// args:
+//   - echo.Context:	コンテキスト
+//
+// return:
+// error:	エラー
+func (ic *interactionController) GetTodayCheckins(c echo.Context) error {
+	checkins, err := ic.ch.GetTodayCheckins(c)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, checkins)
 }

--- a/internal/interaction/controller/interaction_controller.go
+++ b/internal/interaction/controller/interaction_controller.go
@@ -16,6 +16,7 @@ type IInteractionController interface {
 	AddBookmark(echo.Context) error
 	DeleteBookmarks(echo.Context) error
 	CheckinDogrun(echo.Context) error
+	CheckoutDogrun(echo.Context) error
 }
 
 type interactionController struct {
@@ -99,7 +100,7 @@ func (ic *interactionController) DeleteBookmarks(c echo.Context) error {
 
 }
 
-// CheckinDogrun: ドッグランへのチェックイン
+// CheckinDogrun: ドッグランへのチェックイン（入場記録）
 //
 // args:
 //   - echo.Context:	コンテキスト
@@ -125,6 +126,38 @@ func (ic *interactionController) CheckinDogrun(c echo.Context) error {
 	}
 
 	err := ic.ch.CheckinDogrun(c, reqBody)
+	if err != nil {
+		return err
+	}
+	return c.NoContent(http.StatusCreated)
+}
+
+// CheckoutDogrun: ドッグランへのチェックアウト（退場記録）
+//
+// args:
+//   - echo.Context:	コンテキスト
+//
+// return:
+// error:	　エラー
+func (ic *interactionController) CheckoutDogrun(c echo.Context) error {
+	logger := log.GetLogger(c).Sugar()
+
+	reqBody := dto.CheckoutReq{}
+	if err := c.Bind(&reqBody); err != nil {
+		err = errors.NewWRError(err, "チェックアウトリクエストが不正です", errors.NewInteractionClientErrorEType())
+		logger.Error(err)
+		return err
+	}
+	// バリデータのインスタンス作成
+	validate := validator.New()
+	//リクエストボディのバリデーション
+	if err := validate.Struct(reqBody); err != nil {
+		err = errors.NewWRError(err, "リクエストがバリデーションに違反しています", errors.NewInteractionClientErrorEType())
+		logger.Error(err)
+		return err
+	}
+
+	err := ic.ch.CheckoutDogrun(c, reqBody)
 	if err != nil {
 		return err
 	}

--- a/internal/interaction/controller/interaction_controller.go
+++ b/internal/interaction/controller/interaction_controller.go
@@ -12,17 +12,19 @@ import (
 	"github.com/wanrun-develop/wanrun/pkg/log"
 )
 
-type IBookmarkController interface {
+type IInteractionController interface {
 	AddBookmark(echo.Context) error
 	DeleteBookmarks(echo.Context) error
+	CheckinDogrun(echo.Context) error
 }
 
-type bookmarkController struct {
-	h handler.IBookmarkHandler
+type interactionController struct {
+	bh handler.IBookmarkHandler
+	ch handler.ICheckInOutHandler
 }
 
-func NewBookmarkController(bh handler.IBookmarkHandler) IBookmarkController {
-	return &bookmarkController{bh}
+func NewInteractionController(bh handler.IBookmarkHandler, ch handler.ICheckInOutHandler) IInteractionController {
+	return &interactionController{bh, ch}
 }
 
 // AddBookmark: ブックマークの追加
@@ -32,7 +34,7 @@ func NewBookmarkController(bh handler.IBookmarkHandler) IBookmarkController {
 //
 // return:
 //   - error:	エラー
-func (bc *bookmarkController) AddBookmark(c echo.Context) error {
+func (ic *interactionController) AddBookmark(c echo.Context) error {
 	logger := log.GetLogger(c).Sugar()
 
 	reqBody := dto.BookmarkAddReq{}
@@ -53,7 +55,7 @@ func (bc *bookmarkController) AddBookmark(c echo.Context) error {
 	}
 
 	//本処理
-	bookmarkId, err := bc.h.AddBookmark(c, reqBody)
+	bookmarkId, err := ic.bh.AddBookmark(c, reqBody)
 	if err != nil {
 		return err
 	}
@@ -63,14 +65,14 @@ func (bc *bookmarkController) AddBookmark(c echo.Context) error {
 	})
 }
 
-// DeleteBookmarks: ブックマーク済みドッグランの取得
+// DeleteBookmarks: ブックマーク削除
 //
 // args:
 //   - echo.Context:	コンテキスト
 //
 // return:
 //   - error	:	エラー
-func (bc *bookmarkController) DeleteBookmarks(c echo.Context) error {
+func (ic *interactionController) DeleteBookmarks(c echo.Context) error {
 	logger := log.GetLogger(c).Sugar()
 
 	reqBody := dto.BookmarkDeleteReq{}
@@ -89,10 +91,42 @@ func (bc *bookmarkController) DeleteBookmarks(c echo.Context) error {
 		return err
 	}
 
-	if err := bc.h.DeleteBookmark(c, reqBody); err != nil {
+	if err := ic.bh.DeleteBookmark(c, reqBody); err != nil {
 		return err
 	}
 
 	return c.NoContent(http.StatusOK)
 
+}
+
+// CheckinDogrun: ドッグランへのチェックイン
+//
+// args:
+//   - echo.Context:	コンテキスト
+//
+// return:
+// error:	　エラー
+func (ic *interactionController) CheckinDogrun(c echo.Context) error {
+	logger := log.GetLogger(c).Sugar()
+
+	reqBody := dto.CheckinReq{}
+	if err := c.Bind(&reqBody); err != nil {
+		err = errors.NewWRError(err, "チェックインリクエストが不正です", errors.NewInteractionClientErrorEType())
+		logger.Error(err)
+		return err
+	}
+	// バリデータのインスタンス作成
+	validate := validator.New()
+	//リクエストボディのバリデーション
+	if err := validate.Struct(reqBody); err != nil {
+		err = errors.NewWRError(err, "リクエストがバリデーションに違反しています", errors.NewInteractionClientErrorEType())
+		logger.Error(err)
+		return err
+	}
+
+	err := ic.ch.CheckinDogrun(c, reqBody)
+	if err != nil {
+		return err
+	}
+	return c.NoContent(http.StatusCreated)
 }

--- a/internal/interaction/core/dto/interaction_req_dto.go
+++ b/internal/interaction/core/dto/interaction_req_dto.go
@@ -2,9 +2,14 @@ package dto
 
 // bookmark 登録用
 type BookmarkAddReq struct {
-	DogrunIDs []int64 `json:"bookmarkDogrunId" validate:"required,notEmpty"`
+	DogrunIDs []int64 `json:"bookmark_dogrun_id" validate:"required,notEmpty"`
 }
 
 type BookmarkDeleteReq struct {
-	DogrunIDs []int64 `json:"bookmarkDogrunId" validate:"required,notEmpty"`
+	DogrunIDs []int64 `json:"bookmark_dogrun_id" validate:"required,notEmpty"`
+}
+
+type CheckinReq struct {
+	DogrunID int64   `json:"dogrun_id" validate:"required"`
+	DogIDs   []int64 `json:"dog_id" validate:"required"`
 }

--- a/internal/interaction/core/dto/interaction_req_dto.go
+++ b/internal/interaction/core/dto/interaction_req_dto.go
@@ -13,3 +13,8 @@ type CheckinReq struct {
 	DogrunID int64   `json:"dogrun_id" validate:"required"`
 	DogIDs   []int64 `json:"dog_id" validate:"required"`
 }
+
+type CheckoutReq struct {
+	DogrunID int64   `json:"dogrun_id" validate:"required"`
+	DogIDs   []int64 `json:"dog_id" validate:"required"`
+}

--- a/internal/interaction/core/dto/interaction_res_dto.go
+++ b/internal/interaction/core/dto/interaction_res_dto.go
@@ -1,0 +1,10 @@
+package dto
+
+import "time"
+
+type CheckinsRes struct {
+	DogID       int64     `json:"dog_id"`
+	DogrunID    int64     `json:"dogrun_id"`
+	CheckinAt   time.Time `json:"checkin_at"`
+	ReCheckinAt time.Time `json:"re_checkin_at"`
+}

--- a/internal/models/interaction_model.go
+++ b/internal/models/interaction_model.go
@@ -1,6 +1,8 @@
 package model
 
-import "database/sql"
+import (
+	"database/sql"
+)
 
 type DogrunBookmark struct {
 	DogrunBookmarkID sql.NullInt64 `gorm:"column:dogrun_bookmark_id;primaryKey"`
@@ -29,6 +31,9 @@ type DogrunCheckin struct {
 	DogID           sql.NullInt64 `gorm:"column:dog_id;not null"`
 	CheckinAt       sql.NullTime  `gorm:"column:checkin_at;autoCreateTime"`
 	ReCheckinAt     sql.NullTime  `gorm:"column:re_checkin_at;autoUpdateTime"`
+
+	//リレーション
+	Dog Dog `gorm:"foreignKey:DogID;references:DogID"`
 }
 
 func (DogrunCheckin) TableName() string {

--- a/internal/models/interaction_model.go
+++ b/internal/models/interaction_model.go
@@ -48,3 +48,29 @@ DogrunCheckinが空でないか
 func (ci *DogrunCheckin) IsNotEmpty() bool {
 	return ci.DogrunCheckinID.Valid
 }
+
+type DogrunCheckout struct {
+	DogrunCheckoutID sql.NullInt64 `gorm:"column:dogrun_checkout_id;primaryKey"`
+	DogrunID         sql.NullInt64 `gorm:"column:dogrun_id;not null"`
+	DogID            sql.NullInt64 `gorm:"column:dog_id;not null"`
+	CheckoutAt       sql.NullTime  `gorm:"column:checkout_at;autoCreateTime"`
+	ReCheckoutAt     sql.NullTime  `gorm:"column:re_checkout_at;autoUpdateTime"`
+}
+
+func (DogrunCheckout) TableName() string {
+	return "dogrun_checkout"
+}
+
+/*
+DogrunCheckinが空であるか
+*/
+func (co *DogrunCheckout) IsEmpty() bool {
+	return !co.IsNotEmpty()
+}
+
+/*
+DogrunCheckinが空でないか
+*/
+func (co *DogrunCheckout) IsNotEmpty() bool {
+	return co.DogrunCheckoutID.Valid
+}

--- a/internal/models/interaction_model.go
+++ b/internal/models/interaction_model.go
@@ -22,3 +22,29 @@ DogrunBookmarkが空でないか
 func (b *DogrunBookmark) IsNotEmpty() bool {
 	return b.DogrunBookmarkID.Valid
 }
+
+type DogrunCheckin struct {
+	DogrunCheckinID sql.NullInt64 `gorm:"column:dogrun_checkin_id;primaryKey"`
+	DogrunID        sql.NullInt64 `gorm:"column:dogrun_id;not null"`
+	DogID           sql.NullInt64 `gorm:"column:dog_id;not null"`
+	CheckinAt       sql.NullTime  `gorm:"column:checkin_at;autoCreateTime"`
+	ReCheckinAt     sql.NullTime  `gorm:"column:re_checkin_at;autoUpdateTime"`
+}
+
+func (DogrunCheckin) TableName() string {
+	return "dogrun_checkin"
+}
+
+/*
+DogrunCheckinが空であるか
+*/
+func (ci *DogrunCheckin) IsEmpty() bool {
+	return !ci.IsNotEmpty()
+}
+
+/*
+DogrunCheckinが空でないか
+*/
+func (ci *DogrunCheckin) IsNotEmpty() bool {
+	return ci.DogrunCheckinID.Valid
+}

--- a/migrate/migration_sql/000020_dogrun_checkin.down.sql
+++ b/migrate/migration_sql/000020_dogrun_checkin.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS dogrun_checkin CASCADE;
+DROP TABLE IF EXISTS dogrun_checkout CASCADE;

--- a/migrate/migration_sql/000020_dogrun_checkin.up.sql
+++ b/migrate/migration_sql/000020_dogrun_checkin.up.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS dogrun_checkin (
+    dogrun_checkin_id serial primary key,
+    dog_id bigint not null,
+    dogrun_id bigint not null,
+    checkin_at timestamp,
+    re_checkin_at timestamp
+);
+
+CREATE INDEX idx_dogrun_checkin_dogid_dogrunid_checkinat
+ON dogrun_checkin (dog_id, dogrun_id, checkin_at);
+
+
+
+CREATE TABLE IF NOT EXISTS dogrun_checkout (
+    dogrun_checkout_id serial primary key,
+    dog_id bigint not null,
+    dogrun_id bigint not null,
+    checkout_at timestamp,
+    re_checkout_at timestamp
+);
+
+CREATE INDEX idx_dogrun_checkout_dogid_dogrunid_checkoutat
+ON dogrun_checkout (dog_id, dogrun_id, checkout_at);

--- a/migrate/migration_sql/900000_add_foreign_key.down.sql
+++ b/migrate/migration_sql/900000_add_foreign_key.down.sql
@@ -20,3 +20,9 @@ alter table auth_dogrun_managers drop constraint dev_auth_dogrun_managers_dogrun
 
 alter table dogrun_bookmarks drop constraint dev_dogrun_bookmarks_dogrun_id_fkey;
 alter table dogrun_bookmarks drop constraint dev_dogrun_bookmarks_dog_owner_id_fkey; 
+
+alter table dogrun_checkin drop constraint dev_dogrun_checkin_dogrun_id_fkey;
+alter table dogrun_checkin drop constraint dev_dogrun_checkin_dog_id_fkey; 
+
+alter table dogrun_checkout drop constraint dev_dogrun_checkout_dogrun_id_fkey;
+alter table dogrun_checkout drop constraint dev_dogrun_checkout_dog_id_fkey; 

--- a/migrate/migration_sql/900000_add_foreign_key.up.sql
+++ b/migrate/migration_sql/900000_add_foreign_key.up.sql
@@ -31,3 +31,9 @@ alter table auth_dogrun_managers add constraint dev_auth_dogrun_managers_dogrun_
 
 -- `auth_dogrun_managers`と`dogrun_manager_credentials`のリレーション
 alter table dogrun_manager_credentials add constraint dev_dogrun_manager_credentials_auth_dogrun_manager_id_fkey foreign key (auth_dogrun_manager_id) references auth_dogrun_managers (auth_dogrun_manager_id);
+
+alter table dogrun_checkin add constraint dev_dogrun_checkin_dogrun_id_fkey foreign key (dogrun_id) references dogruns (dogrun_id);
+alter table dogrun_checkin add constraint dev_dogrun_checkin_dog_id_fkey foreign key (dog_id) references dogs (dog_id);
+
+alter table dogrun_checkout add constraint dev_dogrun_checkout_dogrun_id_fkey foreign key (dogrun_id) references dogruns (dogrun_id);
+alter table dogrun_checkout add constraint dev_dogrun_checkout_dog_id_fkey foreign key (dog_id) references dogs (dog_id);


### PR DESCRIPTION
## 概要

ドッグランへの入退場記録。
記録対象は、dogとdogrun
複数入場/退場を考慮し、chekcin_atとre_checkin_atを用意（checkoutも同様に）
→途中入退場を考慮しているが、2回目以降はさほど機能としては重要ではないと想定して2回目以降はre_check??_atのみを上書きするのみ）

## 変更点

- 入場：POST: ~/access/checkin
```
{
    "dogrun_id": 4,
    "dog_id": [3]
    
}
```
- 退場：DELETE: ~/access/checkout
（ボディのjson形式はは入場と同様）
- 今日の入場履歴：GET: ~/access/today/checkins
- jwt clalinのroleがint64だったので、intに変更


## 関連Issue

- 関連Issue: #101 
