### PR TITLE
ロール管理機能

### DIFF
--- a/internal/auth/core/constant.go
+++ b/internal/auth/core/constant.go
@@ -1,0 +1,16 @@
+package core
+
+// token authentication
+const (
+	CONTEXT_KEY   string = "user_info"
+	TOKEN_LOOK_UP string = "header:Authorization:Bearer " // `Bearer `しか切り取れないのでスペースが多い場合は未対応
+)
+
+// role
+const (
+	SYSTEM              int = 0
+	DOGRUNMG_ROLE       int = 1
+	DOGRUNMG_ADMIN_ROLE int = 2
+	DOGOWNER_ROLE       int = 3
+	GENERAL             int = 100
+)

--- a/internal/auth/core/handler/auth_handler.go
+++ b/internal/auth/core/handler/auth_handler.go
@@ -39,9 +39,8 @@ func NewAuthHandler(ar repository.IAuthRepository) IAuthHandler {
 
 // JWTのClaims
 type AccountClaims struct {
-	ID   string `json:"id"`
-	JTI  string `json:"jti"`
-	Role int    `json:"role"`
+	UserID string `json:"userId"`
+	Role   int    `json:"role"`
 	jwt.RegisteredClaims
 }
 
@@ -57,7 +56,7 @@ func (claims *AccountClaims) GetDogOwnerIDAsInt64(c echo.Context) (int64, error)
 	logger := log.GetLogger(c).Sugar()
 
 	// IDをstringからint64に変換
-	dogOwnerID, err := strconv.ParseInt(claims.ID, 10, 64)
+	dogOwnerID, err := strconv.ParseInt(claims.UserID, 10, 64)
 	if err != nil {
 		wrErr := errors.NewWRError(
 			nil,
@@ -398,15 +397,15 @@ func createToken(
 
 	// JWTのペイロード
 	claims := AccountClaims{
-		ID:   strconv.FormatInt(uaDTO.UserID, 10), // stringにコンバート
-		JTI:  uaDTO.JwtID,
-		Role: uaDTO.RoleID,
+		UserID: strconv.FormatInt(uaDTO.UserID, 10), // stringにコンバート
+		Role:   uaDTO.RoleID,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate( // 有効時間
 				time.Now().Add(
 					time.Hour * time.Duration(expTime),
 				),
 			),
+			ID: uaDTO.JwtID,
 		},
 	}
 

--- a/internal/auth/core/handler/auth_handler.go
+++ b/internal/auth/core/handler/auth_handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/wanrun-develop/wanrun/configs"
 	"github.com/wanrun-develop/wanrun/internal/auth/adapters/repository"
+	"github.com/wanrun-develop/wanrun/internal/auth/core"
 	authDTO "github.com/wanrun-develop/wanrun/internal/auth/core/dto"
 	"github.com/wanrun-develop/wanrun/pkg/errors"
 	wrErrors "github.com/wanrun-develop/wanrun/pkg/errors"
@@ -43,12 +44,6 @@ type AccountClaims struct {
 	Role int    `json:"role"`
 	jwt.RegisteredClaims
 }
-
-const (
-	DOGRUNMG_ROLE       int = 1
-	DOGRUNMG_ADMIN_ROLE int = 2
-	DOGOWNER_ROLE       int = 3
-)
 
 // GetDogOwnerIDAsInt64: 共通処理で、int64のDogOwnerのID取得。
 //
@@ -152,7 +147,7 @@ func (ah *authHandler) LogInDogowner(c echo.Context, adoReq authDTO.AuthDogOwner
 	dogownerDetail := authDTO.UserAuthInfoDTO{
 		UserID: results[0].AuthDogOwner.DogOwnerID.Int64,
 		JwtID:  jwtID,
-		RoleID: DOGOWNER_ROLE,
+		RoleID: core.DOGOWNER_ROLE,
 	}
 
 	logger.Infof("dogownerDetail: %v", dogownerDetail)
@@ -254,9 +249,9 @@ func (ah *authHandler) LogInDogrunmg(c echo.Context, admReq authDTO.AuthDogrunmg
 	// dogrunmgがadminかどうかの識別
 	var roleID int
 	if results[0].AuthDogrunmg.IsAdmin.Valid && results[0].AuthDogrunmg.IsAdmin.Bool {
-		roleID = DOGRUNMG_ADMIN_ROLE
+		roleID = core.DOGRUNMG_ADMIN_ROLE
 	} else {
-		roleID = DOGRUNMG_ROLE
+		roleID = core.DOGRUNMG_ROLE
 	}
 
 	// 取得したDogrunmgの情報をdto詰め替え

--- a/internal/auth/middleware/jwt.go
+++ b/internal/auth/middleware/jwt.go
@@ -151,7 +151,7 @@ func (aj *authJwt) jwtIDValid(c echo.Context, ac *handler.AccountClaims) error {
 	logger := log.GetLogger(c).Sugar()
 
 	// 共通処理: IDのパース
-	id, err := strconv.ParseInt(ac.ID, 10, 64)
+	id, err := strconv.ParseInt(ac.UserID, 10, 64)
 	if err != nil {
 		wrErr := wrErrs.NewWRError(
 			nil,
@@ -191,7 +191,7 @@ func (aj *authJwt) jwtIDValid(c echo.Context, ac *handler.AccountClaims) error {
 	}
 
 	// JTIの一致確認
-	if jwtID != ac.JTI {
+	if jwtID != ac.ID {
 		wrErr := wrErrs.NewWRError(
 			nil,
 			"jwt_idが一致しません。",

--- a/internal/auth/middleware/role.go
+++ b/internal/auth/middleware/role.go
@@ -1,0 +1,87 @@
+package middleware
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/wanrun-develop/wanrun/internal/auth/core"
+	"github.com/wanrun-develop/wanrun/internal/wrcontext"
+	"github.com/wanrun-develop/wanrun/pkg/errors"
+)
+
+// 全ロール
+var ALL = []int{
+	core.SYSTEM,
+	core.DOGOWNER_ROLE,
+	core.DOGRUNMG_ADMIN_ROLE,
+	core.DOGRUNMG_ROLE,
+	core.GENERAL,
+}
+
+// システムロールのみ (ミドルウェアでシステムユーザーは全て許可済み)
+var SYSTEM = []int{}
+
+// ドッグラン参照
+var DOGRUN_REFER = []int{
+	core.DOGOWNER_ROLE,
+	core.GENERAL,
+	core.DOGRUNMG_ADMIN_ROLE,
+	core.DOGRUNMG_ROLE,
+}
+
+// ドッグラン検索
+var DOGRUN_SEARCH = []int{
+	core.DOGOWNER_ROLE,
+	core.GENERAL,
+}
+
+// 犬管理
+var DOG_MANAGE = []int{
+	core.DOGOWNER_ROLE,
+}
+
+// ドッグラン管理
+var DOGRUN_MANAGE = []int{
+	core.DOGRUNMG_ADMIN_ROLE,
+	core.DOGRUNMG_ROLE,
+}
+
+// ドッグラン特権管理
+var DOGRUN_SUPER_MANAGE = []int{
+	core.DOGRUNMG_ADMIN_ROLE,
+}
+
+// RoleAuthorization: ロール認可
+// トークン認証後、コンテキストのclaim情報からRoleを取得し、認可を検証
+//
+// args:
+//   - echo.Context:	コンテキスト
+//   - []int:	認可対象のロール
+//
+// return:
+//   - echo.MiddlewareFunc:	ミドルウェア
+func RoleAuthorization(allowedRoles []int) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			userRole, err := wrcontext.GetLoginUserRole(c) // Contextからユーザーのロールを取得
+			if err != nil {
+				err = errors.NewWRError(err, "ユーザーのロール認可で失敗しました。", errors.NewAuthServerErrorEType())
+				return err
+			}
+
+			//システムユーザーはチェック対象外
+			for _, systemRole := range SYSTEM {
+				if userRole == systemRole {
+					return nil
+				}
+			}
+
+			//引数の認可対象であるかチェック
+			for _, allowedRole := range allowedRoles {
+				if userRole == allowedRole {
+					return nil // 許可されたロールの場合、次へ進む
+				}
+			}
+
+			return errors.NewWRError(nil, "あなたのユーザーではご利用できない機能です。", errors.NewAuthClientErrorEType())
+		}
+	}
+}

--- a/internal/dogowner/core/handler/dogowner_handler.go
+++ b/internal/dogowner/core/handler/dogowner_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/labstack/echo/v4"
 	authRepository "github.com/wanrun-develop/wanrun/internal/auth/adapters/repository"
+	"github.com/wanrun-develop/wanrun/internal/auth/core"
 	authDTO "github.com/wanrun-develop/wanrun/internal/auth/core/dto"
 	authHandler "github.com/wanrun-develop/wanrun/internal/auth/core/handler"
 	dogOwnerRepository "github.com/wanrun-develop/wanrun/internal/dogowner/adapters/repository"
@@ -143,7 +144,7 @@ func (doh *dogOwnerHandler) DogOwnerSignUp(c echo.Context, doReq doDTO.DogOwnerR
 	dogOwnerDetail := authDTO.UserAuthInfoDTO{
 		UserID: dogOwnerCredential.AuthDogOwner.DogOwnerID.Int64,
 		JwtID:  dogOwnerCredential.AuthDogOwner.JwtID.String,
-		RoleID: authHandler.DOGOWNER_ROLE,
+		RoleID: core.DOGOWNER_ROLE,
 	}
 
 	logger.Infof("dogOwnerDetail: %v", dogOwnerDetail)

--- a/internal/org/core/handler/org_handler.go
+++ b/internal/org/core/handler/org_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/labstack/echo/v4"
 	authRepository "github.com/wanrun-develop/wanrun/internal/auth/adapters/repository"
+	"github.com/wanrun-develop/wanrun/internal/auth/core"
 	authDTO "github.com/wanrun-develop/wanrun/internal/auth/core/dto"
 	authFacade "github.com/wanrun-develop/wanrun/internal/auth/core/facade"
 	authHandler "github.com/wanrun-develop/wanrun/internal/auth/core/handler"
@@ -151,7 +152,7 @@ func (oh *orgHandler) OrgSignUp(
 	dogrunmgrDetail := authDTO.UserAuthInfoDTO{
 		UserID: orgInfo.AuthDogrunmg.DogrunmgID.Int64,
 		JwtID:  orgInfo.AuthDogrunmg.JwtID.String,
-		RoleID: authHandler.DOGRUNMG_ADMIN_ROLE,
+		RoleID: core.DOGRUNMG_ADMIN_ROLE,
 	}
 
 	logger.Infof("dogrunmgDetail: %v", dogrunmgrDetail)

--- a/internal/test.go
+++ b/internal/test.go
@@ -11,6 +11,7 @@ import (
 
 func Test(c echo.Context) error {
 	logger := log.GetLogger(c).Sugar()
+	logger.Info("Test*()の実行. ")
 
 	// dogOwnerID情報の取得
 	dogOwnerID, wrErr := wrcontext.GetLoginUserID(c)
@@ -27,13 +28,12 @@ func Test(c echo.Context) error {
 	}
 
 	// jti情報
-	jti := claims.JTI
+	jti := claims.ID
 	// 有効期限
 	exp := claims.ExpiresAt
 
 	logger.Infof("userID: %v, jti: %v, exp: %v\n", dogOwnerID, jti, exp)
 
-	logger.Info("Test*()の実行. ")
 	if err := testError(); err != nil {
 		err = errors.NewWRError(err, "エラー再生成しました。", errors.NewAuthClientErrorEType())
 		logger.Error(err)

--- a/internal/wrcontext/wrcontext.go
+++ b/internal/wrcontext/wrcontext.go
@@ -4,9 +4,8 @@ import (
 	"strconv"
 
 	"github.com/labstack/echo/v4"
+	"github.com/wanrun-develop/wanrun/internal/auth/core"
 	"github.com/wanrun-develop/wanrun/internal/auth/core/handler"
-	authHandler "github.com/wanrun-develop/wanrun/internal/auth/core/handler"
-	"github.com/wanrun-develop/wanrun/internal/auth/middleware"
 	"github.com/wanrun-develop/wanrun/pkg/errors"
 	"github.com/wanrun-develop/wanrun/pkg/log"
 )
@@ -21,7 +20,7 @@ import (
 func GetVerifiedClaims(c echo.Context) (*handler.AccountClaims, error) {
 	logger := log.GetLogger(c).Sugar()
 
-	claims, ok := c.Get(middleware.CONTEXT_KEY).(*handler.AccountClaims)
+	claims, ok := c.Get(core.CONTEXT_KEY).(*handler.AccountClaims)
 	if !ok || claims == nil {
 		wrErr := errors.NewWRError(
 			nil,
@@ -79,7 +78,7 @@ func GetLoginDogownerID(c echo.Context) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if claims.Role != authHandler.DOGOWNER_ROLE {
+	if claims.Role != core.DOGOWNER_ROLE {
 		err = errors.NewWRError(
 			nil,
 			"このログインユーザーはdogownerではありません。",
@@ -98,4 +97,20 @@ func GetLoginDogownerID(c echo.Context) (int64, error) {
 		return 0, err
 	}
 	return userID, nil
+}
+
+// GetLoginUserRole: ログインユーザー（認証済み）のロールを取得する
+//
+// args:
+//   - echo.Context:	コンテキスト
+//
+// return:
+//   - int:	ロールID
+//   - error:	エラー
+func GetLoginUserRole(c echo.Context) (int, error) {
+	claims, err := GetVerifiedClaims(c)
+	if err != nil {
+		return 0, err
+	}
+	return claims.Role, nil
 }

--- a/internal/wrcontext/wrcontext.go
+++ b/internal/wrcontext/wrcontext.go
@@ -50,7 +50,7 @@ func GetLoginUserID(c echo.Context) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	userID, err := strconv.ParseInt(claims.ID, 10, 64)
+	userID, err := strconv.ParseInt(claims.UserID, 10, 64)
 	if err != nil {
 		logger.Error(err)
 		err = errors.NewWRError(
@@ -86,7 +86,7 @@ func GetLoginDogownerID(c echo.Context) (int64, error) {
 		)
 		return 0, err
 	}
-	userID, err := strconv.ParseInt(claims.ID, 10, 64)
+	userID, err := strconv.ParseInt(claims.UserID, 10, 64)
 	if err != nil {
 		logger.Error(err)
 		err = errors.NewWRError(


### PR DESCRIPTION
## 概要

ロール管理の追加

ユーザーロールとロール認可
各ユーザーロールとエンドポイントごとの認可ロールでのチェック処理

## 変更点
- ロール管理用処理の追加
- 認証系の定数をconstant.goにまとめた
- claimの構造体のJTIをjwt.RegisteredClaimsライブライの変数に変更して元のIDをUserIDに変更

## 影響範囲

認証

## 関連Issue

- 関連Issue: #173 
