### PR TITLE
一般ユーザーのjet発行処理の追加

### DIFF
--- a/cmd/wanrun.go
+++ b/cmd/wanrun.go
@@ -142,11 +142,13 @@ func newRouter(e *echo.Echo, dbConn *gorm.DB) {
 	auth := e.Group("auth")
 	// dogowner
 	auth.POST("/dogowner/token", authController.LogInDogowner)
-	auth.POST("dogowner/revoke", authController.RevokeDogowner, authMW.RoleAuthorization(authMW.DOG_MANAGE))
+	auth.POST("/dogowner/revoke", authController.RevokeDogowner, authMW.RoleAuthorization(authMW.DOG_MANAGE))
 	// auth.GET("/google/oauth", authController.GoogleOAuth)
 	// dogrunmg
-	auth.POST("dogrunmg/token", authController.LogInDogrunmg)
-	auth.POST("dogrunmg/revoke", authController.RevokeDogrunmg, authMW.RoleAuthorization(authMW.DOGRUN_MANAGE))
+	auth.POST("/dogrunmg/token", authController.LogInDogrunmg)
+	auth.POST("/dogrunmg/revoke", authController.RevokeDogrunmg, authMW.RoleAuthorization(authMW.DOGRUN_MANAGE))
+	//general
+	auth.GET("/general/token", authController.IssueGeneralUserToke)
 
 	//interaction関連
 	interactionController := newInteraction(dbConn)

--- a/cmd/wanrun.go
+++ b/cmd/wanrun.go
@@ -148,7 +148,7 @@ func newRouter(e *echo.Echo, dbConn *gorm.DB) {
 	auth.POST("/dogrunmg/token", authController.LogInDogrunmg)
 	auth.POST("/dogrunmg/revoke", authController.RevokeDogrunmg, authMW.RoleAuthorization(authMW.DOGRUN_MANAGE))
 	//general
-	auth.GET("/general/token", authController.IssueGeneralUserToke)
+	auth.GET("/general/token", authController.IssueGeneralUserToken)
 
 	//interaction関連
 	interactionController := newInteraction(dbConn)

--- a/internal/auth/controller/auth_controller.go
+++ b/internal/auth/controller/auth_controller.go
@@ -21,7 +21,7 @@ type IAuthController interface {
 	RevokeDogowner(echo.Context) error
 	RevokeDogrunmg(echo.Context) error
 	// GoogleOAuth(echo.Context) error
-	IssueGeneralUserToke(echo.Context) error
+	IssueGeneralUserToken(echo.Context) error
 }
 
 type authController struct {
@@ -267,7 +267,7 @@ func (ac *authController) RevokeDogrunmg(c echo.Context) error {
 //
 // return:
 //   - error:	エラー
-func (ac *authController) IssueGeneralUserToke(c echo.Context) error {
+func (ac *authController) IssueGeneralUserToken(c echo.Context) error {
 
 	token, wrErr := ac.ah.IssueGeneralUserToke(c)
 	if wrErr != nil {

--- a/internal/auth/controller/auth_controller.go
+++ b/internal/auth/controller/auth_controller.go
@@ -16,11 +16,12 @@ import (
 
 type IAuthController interface {
 	// SignUp(c echo.Context) error
-	LogInDogowner(c echo.Context) error
-	LogInDogrunmg(c echo.Context) error
-	RevokeDogowner(c echo.Context) error
-	RevokeDogrunmg(c echo.Context) error
-	// GoogleOAuth(c echo.Context) error
+	LogInDogowner(echo.Context) error
+	LogInDogrunmg(echo.Context) error
+	RevokeDogowner(echo.Context) error
+	RevokeDogrunmg(echo.Context) error
+	// GoogleOAuth(echo.Context) error
+	IssueGeneralUserToke(echo.Context) error
 }
 
 type authController struct {
@@ -258,3 +259,21 @@ func (ac *authController) RevokeDogrunmg(c echo.Context) error {
 // 	// どちらのパラメータもない場合は不正なリクエストとしてエラーを返す
 // 	return errOAuthInvalidReq
 // }
+
+// IssueGeneralUserToke: 一般ユーザーのjwt発行
+//
+// args:
+//   - echo.Context:	コンテキスト
+//
+// return:
+//   - error:	エラー
+func (ac *authController) IssueGeneralUserToke(c echo.Context) error {
+
+	token, wrErr := ac.ah.IssueGeneralUserToke(c)
+	if wrErr != nil {
+		return wrErr
+	}
+	return c.JSON(http.StatusOK, map[string]string{
+		"accessToken": token,
+	})
+}

--- a/internal/auth/core/constant.go
+++ b/internal/auth/core/constant.go
@@ -14,3 +14,9 @@ const (
 	DOGOWNER_ROLE       int = 3
 	GENERAL             int = 100
 )
+
+// 一般ユーザーのUserID
+const (
+	GENERAL_USER_ID     int64  = -999
+	GENERAL_USER_JWT_ID string = "general"
+)

--- a/internal/auth/core/handler/auth_handler.go
+++ b/internal/auth/core/handler/auth_handler.go
@@ -396,10 +396,10 @@ func createToken(
 ) (string, error) {
 	logger := log.GetLogger(c).Sugar()
 
-	var expireNumericDate *jwt.NumericDate
+	var expiresNumericDate *jwt.NumericDate
 	//0の場合は無期限トークンの発行
 	if expTime != 0 {
-		expireNumericDate = jwt.NewNumericDate( // 有効時間
+		expiresNumericDate = jwt.NewNumericDate( // 有効時間
 			time.Now().Add(
 				time.Hour * time.Duration(expTime),
 			),
@@ -411,7 +411,7 @@ func createToken(
 		UserID: strconv.FormatInt(uaDTO.UserID, 10), // stringにコンバート
 		Role:   uaDTO.RoleID,
 		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: expireNumericDate, // 有効時間
+			ExpiresAt: expiresNumericDate, // 有効時間
 			ID:        uaDTO.JwtID,
 		},
 	}

--- a/internal/auth/core/handler/auth_handler.go
+++ b/internal/auth/core/handler/auth_handler.go
@@ -23,6 +23,7 @@ type IAuthHandler interface {
 	LogInDogrunmg(c echo.Context, ador authDTO.AuthDogrunmgReq) (string, error)
 	RevokeDogrunmg(c echo.Context, dmID int64) error
 	// GoogleOAuth(c echo.Context, authorizationCode string, grantType types.GrantType) (dto.ResDogOwnerDto, error)
+	IssueGeneralUserToke(c echo.Context) (string, error)
 }
 
 type authHandler struct {
@@ -382,7 +383,7 @@ func GetSignedJwt(c echo.Context, uaDTO authDTO.UserAuthInfoDTO) (string, error)
 //   - echo.Context: Echoのコンテキスト。リクエストやレスポンスにアクセスするために使用
 //   - string: secretKey   トークンの署名に使用する秘密鍵を表す文字列
 //   - authDTO.UserAuthInfoDTO: jwtで使用する情報
-//   - int: expTime トークンの有効期限を秒単位で指定
+//   - int: expTime トークンの有効期限を秒単位で指定. 0なら無期限とする
 //
 // return:
 //   - string: 生成されたJWTトークンを表す文字列
@@ -395,17 +396,23 @@ func createToken(
 ) (string, error) {
 	logger := log.GetLogger(c).Sugar()
 
+	var expireNumericDate *jwt.NumericDate
+	//0の場合は無期限トークンの発行
+	if expTime != 0 {
+		expireNumericDate = jwt.NewNumericDate( // 有効時間
+			time.Now().Add(
+				time.Hour * time.Duration(expTime),
+			),
+		)
+	}
+
 	// JWTのペイロード
 	claims := AccountClaims{
 		UserID: strconv.FormatInt(uaDTO.UserID, 10), // stringにコンバート
 		Role:   uaDTO.RoleID,
 		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate( // 有効時間
-				time.Now().Add(
-					time.Hour * time.Duration(expTime),
-				),
-			),
-			ID: uaDTO.JwtID,
+			ExpiresAt: expireNumericDate, // 有効時間
+			ID:        uaDTO.JwtID,
 		},
 	}
 
@@ -483,4 +490,35 @@ func validateEmailOrPhoneNumber(doReq authDTO.AuthDogOwnerReq) error {
 
 	// どちらか片方だけが入力されている場合は正常
 	return nil
+}
+
+// IssueGeneralUserToke: 一般ユーザーのjwr発行処理
+//
+// args:
+//   - echo.Context:	コンテキスト
+//
+// return:
+//   - string:	jwt
+//   - error:	エラー
+func (ah *authHandler) IssueGeneralUserToke(c echo.Context) (string, error) {
+	logger := log.GetLogger(c).Sugar()
+	logger.Info("一般ユーザートークンの発行")
+
+	userInfoDTO := authDTO.UserAuthInfoDTO{
+		UserID: core.GENERAL_USER_ID,
+		JwtID:  core.GENERAL_USER_JWT_ID,
+		RoleID: core.GENERAL,
+	}
+
+	// 秘密鍵取得
+	secretKey := configs.FetchConfigStr("jwt.os.secret.key")
+
+	// jwt token生成(無期限)
+	signedToken, wrErr := createToken(c, secretKey, userInfoDTO, 0)
+
+	if wrErr != nil {
+		return "", wrErr
+	}
+
+	return signedToken, wrErr
 }

--- a/internal/auth/middleware/role.go
+++ b/internal/auth/middleware/role.go
@@ -70,14 +70,16 @@ func RoleAuthorization(allowedRoles []int) echo.MiddlewareFunc {
 			//システムユーザーはチェック対象外
 			for _, systemRole := range SYSTEM {
 				if userRole == systemRole {
-					return nil
+					err := next(c)
+					return err
 				}
 			}
 
 			//引数の認可対象であるかチェック
 			for _, allowedRole := range allowedRoles {
 				if userRole == allowedRole {
-					return nil // 許可されたロールの場合、次へ進む
+					err := next(c) // 許可されたロールの場合、次へ進む
+					return err
 				}
 			}
 

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -24,10 +24,8 @@ func RequestLoggerMiddleware(logger *zap.Logger) echo.MiddlewareFunc {
 				zap.String("method", c.Request().Method),
 				zap.String("path", c.Request().URL.Path),
 				zap.Int("bytes_in", int(c.Request().ContentLength)),
+				zap.Any("header", c.Request().Header),
 			)
-
-			// コンテキストにロガーをセット
-			c.Set("logger", reqLogger)
 
 			// リクエスト処理の開始時間
 			start := time.Now()
@@ -55,7 +53,7 @@ func GetLogger(c echo.Context) *zap.Logger {
 	}
 	requestID := c.Response().Header().Get(echo.HeaderXRequestID)
 	logger := gLogger.With(zap.String("request_id", requestID))
-	logger.Debug("コンテキストにlogerがないため、生成してコンテキストにセット")
+	logger.Debug("コンテキストにloggerがないため、生成してコンテキストにセット")
 	c.Set("logger", logger) // コンテキストにロガーをセット
 	return logger
 }


### PR DESCRIPTION
## 概要
一般ユーザーの認証トークン(JWT)の発行処理
共通的なjwt認証と認可を行うため、jwtを発行する

## 変更点

- GET:auth/general/token　の追加
- jwt認証のミドルウェアのskipperに使っていた、c.Pathを修正
- ロール認可不具合修正

## 影響範囲
いろいろ

## 関連Issue

- 関連Issue: #167
