### PR TITLE
リフレッシュトークン処理

### DIFF
--- a/configs/configs.go
+++ b/configs/configs.go
@@ -76,7 +76,8 @@ func bindEnvs() {
 	_ = v.BindEnv("env", "ENV")
 	_ = v.BindEnv("google.place.api.key", "GOOGLE_PLACE_API_KEY")
 	_ = v.BindEnv("jwt.os.secret.key", "SECRET_KEY")                // jwt生成用の秘密鍵
-	_ = v.BindEnv("jwt.exp.time", "JWT_EXP_TIME")                   // jwt生成用の秘密鍵
+	_ = v.BindEnv("jwt.exp.time", "JWT_EXP_TIME")                   // jwt生成用の有効期限（時間）
+	_ = v.BindEnv("refresh.jwt.exp.time", "REFRESH_JWT_EXP_TIME")   // jwt生成用の有効期限（時間）
 	_ = v.BindEnv("gcp.client.id", "GCP_CLIENT_ID")                 // oauthの際のgcp credentials
 	_ = v.BindEnv("gcp.client.secret", "GCP_CLIENT_SECRET")         // oauthの際のgcp credentials
 	_ = v.BindEnv("gcp.redirect.uri", "GCP_REDIRECT_URI")           // oauthの際のgcp credentials

--- a/internal/auth/controller/auth_controller.go
+++ b/internal/auth/controller/auth_controller.go
@@ -144,9 +144,7 @@ func (ac *authController) LogInDogowner(c echo.Context) error {
 		return wrErr
 	}
 
-	return c.JSON(http.StatusOK, map[string]string{
-		"accessToken": token,
-	})
+	return c.JSON(http.StatusOK, token)
 }
 
 // RevokeDogowner: dogownerのrevoke機能
@@ -210,9 +208,7 @@ func (ac *authController) LogInDogrunmg(c echo.Context) error {
 		return wrErr
 	}
 
-	return c.JSON(http.StatusOK, map[string]string{
-		"accessToken": token,
-	})
+	return c.JSON(http.StatusOK, token)
 }
 
 // RevokeDogrunmg: dogrunmgのrevoke機能
@@ -273,7 +269,5 @@ func (ac *authController) IssueGeneralUserToken(c echo.Context) error {
 	if wrErr != nil {
 		return wrErr
 	}
-	return c.JSON(http.StatusOK, map[string]string{
-		"accessToken": token,
-	})
+	return c.JSON(http.StatusOK, token)
 }

--- a/internal/auth/core/constant.go
+++ b/internal/auth/core/constant.go
@@ -20,3 +20,9 @@ const (
 	GENERAL_USER_ID     int64  = -999
 	GENERAL_USER_JWT_ID string = "general"
 )
+
+// 認証方法
+const (
+	PASSWORD string = "password"
+	REFRESH  string = "refresh"
+)

--- a/internal/auth/core/dto/auth_dog_owner_dto.go
+++ b/internal/auth/core/dto/auth_dog_owner_dto.go
@@ -1,9 +1,9 @@
 package dto
 
 type AuthDogOwnerReq struct {
-	Password          string `json:"password"`
-	DogOwnerName      string `json:"dogOwnerName"`
-	Email             string `json:"email"`
-	PhoneNumber       string `json:"phoneNumber"`
-	AuthorizationCode string
+	Password           string `json:"password"`
+	Email              string `json:"email"`
+	PhoneNumber        string `json:"phoneNumber"`
+	RefreshToken       string `json:"refreshToken"`
+	AuthenticationType string `json:"authenticationType"`
 }

--- a/internal/auth/core/dto/auth_user_info_dto.go
+++ b/internal/auth/core/dto/auth_user_info_dto.go
@@ -1,7 +1,17 @@
 package dto
 
-type UserAuthInfoDTO struct {
+type AuthUserInfoDTO struct {
 	UserID int64
-	JwtID  string
 	RoleID int
+}
+
+type JwtInfoDTO struct {
+	AuthUserInfoDTO
+	JwtID        string
+	RefreshJwtID string
+}
+
+type IssuedJwT struct {
+	AccessToken  string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken,omitempty"`
 }

--- a/internal/auth/core/dto/auth_user_info_dto.go
+++ b/internal/auth/core/dto/auth_user_info_dto.go
@@ -11,7 +11,7 @@ type JwtInfoDTO struct {
 	RefreshJwtID string
 }
 
-type IssuedJwT struct {
+type IssuedJwtRes struct {
 	AccessToken  string `json:"accessToken"`
 	RefreshToken string `json:"refreshToken,omitempty"`
 }

--- a/internal/auth/core/handler/auth_handler.go
+++ b/internal/auth/core/handler/auth_handler.go
@@ -1,7 +1,7 @@
 package handler
 
 import (
-	"strconv"
+	"fmt"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -10,7 +10,7 @@ import (
 	"github.com/wanrun-develop/wanrun/internal/auth/adapters/repository"
 	"github.com/wanrun-develop/wanrun/internal/auth/core"
 	authDTO "github.com/wanrun-develop/wanrun/internal/auth/core/dto"
-	"github.com/wanrun-develop/wanrun/pkg/errors"
+	model "github.com/wanrun-develop/wanrun/internal/models"
 	wrErrors "github.com/wanrun-develop/wanrun/pkg/errors"
 	"github.com/wanrun-develop/wanrun/pkg/log"
 	"github.com/wanrun-develop/wanrun/pkg/util"
@@ -18,12 +18,12 @@ import (
 )
 
 type IAuthHandler interface {
-	LogInDogowner(c echo.Context, ador authDTO.AuthDogOwnerReq) (string, error)
+	LogInDogowner(c echo.Context, ador authDTO.AuthDogOwnerReq) (authDTO.IssuedJwT, error)
 	RevokeDogowner(c echo.Context, dogownerID int64) error
-	LogInDogrunmg(c echo.Context, ador authDTO.AuthDogrunmgReq) (string, error)
+	LogInDogrunmg(c echo.Context, ador authDTO.AuthDogrunmgReq) (authDTO.IssuedJwT, error)
 	RevokeDogrunmg(c echo.Context, dmID int64) error
 	// GoogleOAuth(c echo.Context, authorizationCode string, grantType types.GrantType) (dto.ResDogOwnerDto, error)
-	IssueGeneralUserToke(c echo.Context) (string, error)
+	IssueGeneralUserToke(c echo.Context) (authDTO.IssuedJwT, error)
 }
 
 type authHandler struct {
@@ -40,34 +40,9 @@ func NewAuthHandler(ar repository.IAuthRepository) IAuthHandler {
 
 // JWTのClaims
 type AccountClaims struct {
-	UserID string `json:"userId"`
-	Role   int    `json:"role"`
+	UserID int64 `json:"userId"`
+	Role   int   `json:"role"`
 	jwt.RegisteredClaims
-}
-
-// GetDogOwnerIDAsInt64: 共通処理で、int64のDogOwnerのID取得。
-//
-// args:
-//   - echo.Context: Echoのコンテキスト。リクエストやレスポンスにアクセスするために使用
-//
-// return:
-//   - int64: dogOwnerのID情報(int64)
-//   - error: error情報
-func (claims *AccountClaims) GetDogOwnerIDAsInt64(c echo.Context) (int64, error) {
-	logger := log.GetLogger(c).Sugar()
-
-	// IDをstringからint64に変換
-	dogOwnerID, err := strconv.ParseInt(claims.UserID, 10, 64)
-	if err != nil {
-		wrErr := errors.NewWRError(
-			nil,
-			"認証情報が違います。",
-			errors.NewDogOwnerClientErrorEType(),
-		)
-		logger.Error(wrErr)
-		return 0, err
-	}
-	return dogOwnerID, nil
 }
 
 // LogInDogowner: dogownerの存在チェックバリデーションとJWTの更新, 署名済みjwtを返す
@@ -77,24 +52,106 @@ func (claims *AccountClaims) GetDogOwnerIDAsInt64(c echo.Context) (int64, error)
 //   - dto.AuthDogOwnerReq: authDogOwnerのリクエスト情報
 //
 // return:
-//   - string: 検証済みのjwt
+//   - authDTO.IssuedJwT: 発行済みのjwt
 //   - error: error情報
-func (ah *authHandler) LogInDogowner(c echo.Context, adoReq authDTO.AuthDogOwnerReq) (string, error) {
+func (ah *authHandler) LogInDogowner(c echo.Context, adoReq authDTO.AuthDogOwnerReq) (authDTO.IssuedJwT, error) {
 	logger := log.GetLogger(c).Sugar()
 
+	ado := model.AuthDogOwner{}
+	var err error
+
+	if adoReq.AuthenticationType == core.PASSWORD {
+		//リクエスト検証
+		ado, err = ah.VerifyRequestAndFetchAuthDogOwnerPassword(c, adoReq)
+		if err != nil {
+			return authDTO.IssuedJwT{}, err
+		}
+	} else if adoReq.AuthenticationType == core.REFRESH {
+		if adoReq.RefreshToken == "" {
+			wrErr := wrErrors.NewWRError(
+				nil,
+				"認証トークンの再発行にはリフレッシュトークンが必要です。",
+				wrErrors.NewAuthClientErrorEType())
+			logger.Errorf("refresh token is required: %v", wrErr)
+			return authDTO.IssuedJwT{}, wrErr
+		}
+		//リクエスト検証
+		ado, err = ah.VerifyRequestAndFetchAuthDogOwnerRefresh(c, adoReq.RefreshToken)
+		if err != nil {
+			return authDTO.IssuedJwT{}, err
+		}
+	} else {
+		wrErr := wrErrors.NewWRError(
+			nil,
+			"適切な認証方法'AuthenticationType'が指定されていません",
+			wrErrors.NewAuthClientErrorEType())
+		logger.Errorf("AuthenticationType is invalid: %v", wrErr)
+		return authDTO.IssuedJwT{}, wrErr
+	}
+
+	// 認証トークンのJWT IDの生成
+	jwtID, wrErr := GenerateJwtID(c)
+	if wrErr != nil {
+		return authDTO.IssuedJwT{}, wrErr
+	}
+	logger.Infoln("jwt_id", jwtID)
+
+	// リフレッシュトークンのJWT IDの生成
+	refreshJwtID, wrErr := GenerateJwtID(c)
+	if wrErr != nil {
+		return authDTO.IssuedJwT{}, wrErr
+	}
+	logger.Infoln("refresh_jwt_id", refreshJwtID)
+
+	// 取得したdogownerのjtw_idの更新
+	if wrErr := ah.ar.UpdateDogownerJwtID(c, ado.DogOwnerID.Int64, jwtID, refreshJwtID); wrErr != nil {
+		return authDTO.IssuedJwT{}, wrErr
+	}
+
+	// 作成したDogownerの情報をdto詰め替え
+	jiDTO := authDTO.JwtInfoDTO{
+		AuthUserInfoDTO: authDTO.AuthUserInfoDTO{
+			UserID: ado.DogOwnerID.Int64,
+			RoleID: core.DOGOWNER_ROLE,
+		},
+		JwtID:        jwtID,
+		RefreshJwtID: refreshJwtID,
+	}
+	logger.Infof("dogownerDetail: %v", jiDTO)
+
+	// 署名済みのjwt token取得
+	token, refreshToken, wrErr := GetSignedJwt(c, jiDTO)
+	if wrErr != nil {
+		return authDTO.IssuedJwT{}, wrErr
+	}
+
+	return authDTO.IssuedJwT{AccessToken: token, RefreshToken: refreshToken}, nil
+}
+
+// VerifyRequestAndFetchAuthDogOwnerPassword	: パスワード認証時のユーザー認証のリクエスト検証とユーザー取得
+// メールアドレスか電話番号のチェック
+// auth_dog_owner系へ取得とチェック
+//
+// args:
+//   - echo.Context:	コンテキスト
+//   - authDTO.AuthDogOwnerReq:	リクエストボディ
+//
+// return:
+//   - model.AuthDogOwner:	認証ユーザー
+//   - error:	エラー
+func (ah *authHandler) VerifyRequestAndFetchAuthDogOwnerPassword(c echo.Context, adoReq authDTO.AuthDogOwnerReq) (model.AuthDogOwner, error) {
+	logger := log.GetLogger(c).Sugar()
 	// EmailとPhoneNumberのバリデーション
 	if wrErr := validateEmailOrPhoneNumber(adoReq); wrErr != nil {
 		logger.Error(wrErr)
-		return "", wrErr
+		return model.AuthDogOwner{}, wrErr
 	}
-
 	logger.Debugf("authDogownerReq: %v, Type: %T", adoReq, adoReq)
 
 	// EmailかPhoneNumberから対象のDogowner情報の取得
 	results, wrErr := ah.ar.GetDogOwnerByCredentials(c, adoReq)
-
 	if wrErr != nil {
-		return "", wrErr
+		return model.AuthDogOwner{}, wrErr
 	}
 
 	// 対象のdogownerがいない場合
@@ -105,9 +162,8 @@ func (ah *authHandler) LogInDogowner(c echo.Context, adoReq authDTO.AuthDogOwner
 			wrErrors.NewAuthClientErrorEType(),
 		)
 		logger.Errorf("Dogowner not found: %v", wrErr)
-		return "", wrErr
+		return model.AuthDogOwner{}, wrErr
 	}
-
 	// 対象のdogownerが複数いるため、データの不整合が起きている(基本的に起きない)
 	if len(results) > 1 {
 		wrErr := wrErrors.NewWRError(
@@ -116,7 +172,7 @@ func (ah *authHandler) LogInDogowner(c echo.Context, adoReq authDTO.AuthDogOwner
 			wrErrors.NewAuthServerErrorEType(),
 		)
 		logger.Errorf("Multiple records found: %v", wrErr)
-		return "", wrErr
+		return model.AuthDogOwner{}, wrErr
 	}
 
 	// パスワードの確認
@@ -125,41 +181,61 @@ func (ah *authHandler) LogInDogowner(c echo.Context, adoReq authDTO.AuthDogOwner
 			err,
 			"パスワードが間違っています",
 			wrErrors.NewAuthServerErrorEType())
-
 		logger.Errorf("Password compare failure: %v", wrErr)
-
-		return "", wrErr
+		return model.AuthDogOwner{}, wrErr
 	}
 
-	// 更新用のJWT IDの生成
-	jwtID, wrErr := GenerateJwtID(c)
+	return results[0].AuthDogOwner, nil
+}
 
-	if wrErr != nil {
-		return "", wrErr
+// VerifyRequestAndFetchAuthDogOwnerRefresh:
+//
+// args:
+//   - echo.Context:	コンテキスト
+//   - string:	リフレッシュトークン
+//
+// return:
+//   - model.AuthDogOwner:	認証ユーザー
+//   - error:	エラー
+func (ah *authHandler) VerifyRequestAndFetchAuthDogOwnerRefresh(c echo.Context, refreshToken string) (model.AuthDogOwner, error) {
+	logger := log.GetLogger(c).Sugar()
+
+	claims := &AccountClaims{}
+
+	// 署名キーを指定
+	token, err := jwt.ParseWithClaims(refreshToken, claims, func(token *jwt.Token) (interface{}, error) {
+		// 署名アルゴリズムが適切かチェック
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			err := wrErrors.NewWRError(nil, fmt.Sprintf("unexpected signing method: %v", token.Header["alg"]), wrErrors.NewAuthServerErrorEType())
+			logger.Error(err)
+			return nil, err
+		}
+		return []byte(configs.FetchConfigStr("jwt.os.secret.key")), nil
+	})
+	if err != nil {
+		err := wrErrors.NewWRError(err, "リフレッシュトークンの著名検証に失敗しました。", wrErrors.NewAuthServerErrorEType())
+		return model.AuthDogOwner{}, err
 	}
 
-	// 取得したdogownerのjtw_idの更新
-	if wrErr := ah.ar.UpdateDogownerJwtID(c, results[0].AuthDogOwner.DogOwner.DogOwnerID.Int64, jwtID); wrErr != nil {
-		return "", wrErr
+	// クレームを取得
+	refreshClaim, ok := token.Claims.(*AccountClaims)
+	if !ok || !token.Valid {
+		err = wrErrors.NewWRError(nil, "リフレッシュトークンは不正です。", wrErrors.NewAuthServerErrorEType())
+		logger.Error(err)
+		return model.AuthDogOwner{}, err
 	}
 
-	// 作成したDogownerの情報をdto詰め替え
-	dogownerDetail := authDTO.UserAuthInfoDTO{
-		UserID: results[0].AuthDogOwner.DogOwnerID.Int64,
-		JwtID:  jwtID,
-		RoleID: core.DOGOWNER_ROLE,
+	//jtiの検証
+	ado, err := ah.ar.GetAuthDogOwnerByID(c, refreshClaim.UserID)
+	if err != nil {
+		return model.AuthDogOwner{}, err
 	}
-
-	logger.Infof("dogownerDetail: %v", dogownerDetail)
-
-	// 署名済みのjwt token取得
-	token, wrErr := GetSignedJwt(c, dogownerDetail)
-
-	if wrErr != nil {
-		return "", wrErr
+	if ado.RefreshJwtID.String != refreshClaim.ID {
+		err = wrErrors.NewWRError(nil, "リフレッシュトークンは有効でないか、すでに失効済みです。", wrErrors.NewAuthServerErrorEType())
+		logger.Error(err)
+		return model.AuthDogOwner{}, err
 	}
-
-	return token, nil
+	return ado, nil
 }
 
 // RevokeDogowner: dogownerのRevoke機能
@@ -188,7 +264,7 @@ func (ah *authHandler) RevokeDogowner(c echo.Context, doID int64) error {
 // return:
 //   - string: 検証済みのjwt
 //   - error: error情報
-func (ah *authHandler) LogInDogrunmg(c echo.Context, admReq authDTO.AuthDogrunmgReq) (string, error) {
+func (ah *authHandler) LogInDogrunmg(c echo.Context, admReq authDTO.AuthDogrunmgReq) (authDTO.IssuedJwT, error) {
 	logger := log.GetLogger(c).Sugar()
 
 	logger.Debugf("authDogrunmgReq: %v, Type: %T", admReq, admReq)
@@ -197,7 +273,7 @@ func (ah *authHandler) LogInDogrunmg(c echo.Context, admReq authDTO.AuthDogrunmg
 	results, err := ah.ar.GetDogrunmgByCredentials(c, admReq.Email)
 
 	if err != nil {
-		return "", err
+		return authDTO.IssuedJwT{}, err
 	}
 
 	// 対象のdogrunmgがいない場合
@@ -208,7 +284,7 @@ func (ah *authHandler) LogInDogrunmg(c echo.Context, admReq authDTO.AuthDogrunmg
 			wrErrors.NewAuthClientErrorEType(),
 		)
 		logger.Errorf("Dogrunmg not found: %v", wrErr)
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// 対象のdogrunmgが複数いるため、データの不整合が起きている(emailをuniqueにしているため基本的に起きない)
@@ -219,7 +295,7 @@ func (ah *authHandler) LogInDogrunmg(c echo.Context, admReq authDTO.AuthDogrunmg
 			wrErrors.NewAuthServerErrorEType(),
 		)
 		logger.Errorf("Multiple records found for email (expected unique): %v", wrErr)
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// パスワードの確認
@@ -231,19 +307,19 @@ func (ah *authHandler) LogInDogrunmg(c echo.Context, admReq authDTO.AuthDogrunmg
 
 		logger.Errorf("Password compare failure: %v", wrErr)
 
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// 更新用のJWT IDの生成
 	jwtID, wrErr := GenerateJwtID(c)
 
 	if wrErr != nil {
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// 取得したdogrunmgのjwt_idの更新
 	if wrErr = ah.ar.UpdateDogrunmgJwtID(c, results[0].AuthDogrunmg.Dogrunmg.DogrunmgID.Int64, jwtID); wrErr != nil {
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// dogrunmgがadminかどうかの識別
@@ -255,22 +331,23 @@ func (ah *authHandler) LogInDogrunmg(c echo.Context, admReq authDTO.AuthDogrunmg
 	}
 
 	// 取得したDogrunmgの情報をdto詰め替え
-	dogrunmgDetail := authDTO.UserAuthInfoDTO{
-		UserID: results[0].AuthDogrunmg.DogrunmgID.Int64,
-		JwtID:  jwtID,
-		RoleID: roleID,
+	dogrunmgDetail := authDTO.JwtInfoDTO{
+		AuthUserInfoDTO: authDTO.AuthUserInfoDTO{
+			UserID: results[0].AuthDogrunmg.DogrunmgID.Int64,
+			RoleID: roleID,
+		},
+		JwtID: jwtID,
 	}
 
 	logger.Infof("dogrunmgDetail: %v", dogrunmgDetail)
 
 	// 署名済みのjwt token取得
-	token, wrErr := GetSignedJwt(c, dogrunmgDetail)
-
+	token, refreshToken, wrErr := GetSignedJwt(c, dogrunmgDetail)
 	if wrErr != nil {
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
-	return token, nil
+	return authDTO.IssuedJwT{AccessToken: token, RefreshToken: refreshToken}, nil
 }
 
 // RevokeDogrunmg: dogrunmgのRevoke機能
@@ -357,24 +434,35 @@ Google OAuth認証
 //
 // args:
 //   - echo.Context: Echoのコンテキスト。リクエストやレスポンスにアクセスするために使用
-//   - authDTO.UserAuthInfoDTO: jwtで使用する情報
+//   - authDTO.JwtInfoDTO: jwtで使用する情報
 //
 // return:
-//   - string: 署名したtoken
+//   - string: 署名した認証トークン
+//   - string: 署名したリフレッシュトークン
 //   - error: error情報
-func GetSignedJwt(c echo.Context, uaDTO authDTO.UserAuthInfoDTO) (string, error) {
+func GetSignedJwt(c echo.Context, jiDTO authDTO.JwtInfoDTO) (string, string, error) {
 	// 秘密鍵取得
 	secretKey := configs.FetchConfigStr("jwt.os.secret.key")
 	jwtExpTime := configs.FetchConfigInt("jwt.exp.time")
 
-	// jwt token生成
-	signedToken, wrErr := createToken(c, secretKey, uaDTO, jwtExpTime)
-
+	// jwt 認証トークン生成
+	signedToken, wrErr := createToken(c, secretKey, jiDTO.AuthUserInfoDTO, jiDTO.JwtID, jwtExpTime)
 	if wrErr != nil {
-		return "", wrErr
+		return "", "", wrErr
 	}
 
-	return signedToken, wrErr
+	if jiDTO.RefreshJwtID == "" {
+		return signedToken, "", nil
+	}
+
+	RefreshJwtExpTime := configs.FetchConfigInt("refresh.jwt.exp.time")
+	// jwt リフレッシュトークン生成
+	signedRefreshToken, wrErr := createToken(c, secretKey, jiDTO.AuthUserInfoDTO, jiDTO.RefreshJwtID, RefreshJwtExpTime)
+	if wrErr != nil {
+		return "", "", wrErr
+	}
+
+	return signedToken, signedRefreshToken, nil
 }
 
 // createToken: 指定された秘密鍵を使用して認証用のJWTトークンを生成
@@ -383,6 +471,7 @@ func GetSignedJwt(c echo.Context, uaDTO authDTO.UserAuthInfoDTO) (string, error)
 //   - echo.Context: Echoのコンテキスト。リクエストやレスポンスにアクセスするために使用
 //   - string: secretKey   トークンの署名に使用する秘密鍵を表す文字列
 //   - authDTO.UserAuthInfoDTO: jwtで使用する情報
+//   - jwtID:	jwt_id値
 //   - int: expTime トークンの有効期限を秒単位で指定. 0なら無期限とする
 //
 // return:
@@ -391,7 +480,8 @@ func GetSignedJwt(c echo.Context, uaDTO authDTO.UserAuthInfoDTO) (string, error)
 func createToken(
 	c echo.Context,
 	secretKey string,
-	uaDTO authDTO.UserAuthInfoDTO,
+	uaDTO authDTO.AuthUserInfoDTO,
+	jwtID string,
 	expTime int,
 ) (string, error) {
 	logger := log.GetLogger(c).Sugar()
@@ -408,14 +498,13 @@ func createToken(
 
 	// JWTのペイロード
 	claims := AccountClaims{
-		UserID: strconv.FormatInt(uaDTO.UserID, 10), // stringにコンバート
+		UserID: uaDTO.UserID, // stringにコンバート
 		Role:   uaDTO.RoleID,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: expiresNumericDate, // 有効時間
-			ID:        uaDTO.JwtID,
+			ID:        jwtID,
 		},
 	}
-
 	// token生成
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
@@ -500,13 +589,12 @@ func validateEmailOrPhoneNumber(doReq authDTO.AuthDogOwnerReq) error {
 // return:
 //   - string:	jwt
 //   - error:	エラー
-func (ah *authHandler) IssueGeneralUserToke(c echo.Context) (string, error) {
+func (ah *authHandler) IssueGeneralUserToke(c echo.Context) (authDTO.IssuedJwT, error) {
 	logger := log.GetLogger(c).Sugar()
 	logger.Info("一般ユーザートークンの発行")
 
-	userInfoDTO := authDTO.UserAuthInfoDTO{
+	auiDTO := authDTO.AuthUserInfoDTO{
 		UserID: core.GENERAL_USER_ID,
-		JwtID:  core.GENERAL_USER_JWT_ID,
 		RoleID: core.GENERAL,
 	}
 
@@ -514,11 +602,11 @@ func (ah *authHandler) IssueGeneralUserToke(c echo.Context) (string, error) {
 	secretKey := configs.FetchConfigStr("jwt.os.secret.key")
 
 	// jwt token生成(無期限)
-	signedToken, wrErr := createToken(c, secretKey, userInfoDTO, 0)
+	signedToken, wrErr := createToken(c, secretKey, auiDTO, core.GENERAL_USER_JWT_ID, 0)
 
 	if wrErr != nil {
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
-	return signedToken, wrErr
+	return authDTO.IssuedJwT{AccessToken: signedToken}, wrErr
 }

--- a/internal/auth/core/handler/auth_handler.go
+++ b/internal/auth/core/handler/auth_handler.go
@@ -203,7 +203,7 @@ func (ah *authHandler) VerifyRequestAndFetchAuthDogOwnerRefresh(c echo.Context, 
 	claims := &AccountClaims{}
 
 	// 署名キーを指定
-	token, err := jwt.ParseWithClaims(refreshToken, claims, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(refreshToken, claims, func(token *jwt.Token) (any, error) {
 		// 署名アルゴリズムが適切かチェック
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			err := wrErrors.NewWRError(nil, fmt.Sprintf("unexpected signing method: %v", token.Header["alg"]), wrErrors.NewAuthServerErrorEType())
@@ -498,7 +498,7 @@ func createToken(
 
 	// JWTのペイロード
 	claims := AccountClaims{
-		UserID: uaDTO.UserID, // stringにコンバート
+		UserID: uaDTO.UserID,
 		Role:   uaDTO.RoleID,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: expiresNumericDate, // 有効時間

--- a/internal/auth/middleware/jwt.go
+++ b/internal/auth/middleware/jwt.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -157,18 +156,6 @@ func (aj *authJwt) extractAndValidateJwtClaims(c echo.Context) (*handler.Account
 func (aj *authJwt) jwtIDValid(c echo.Context, ac *handler.AccountClaims) error {
 	logger := log.GetLogger(c).Sugar()
 
-	// 共通処理: IDのパース
-	id, err := strconv.ParseInt(ac.UserID, 10, 64)
-	if err != nil {
-		wrErr := wrErrs.NewWRError(
-			nil,
-			"認証情報が異なります",
-			wrErrs.NewAuthClientErrorEType(),
-		)
-		logger.Error(wrErr)
-		return wrErr
-	}
-
 	// Roleによる設定分岐
 	getJwtID := func(role int, id int64) (string, error) {
 		switch role {
@@ -194,7 +181,7 @@ func (aj *authJwt) jwtIDValid(c echo.Context, ac *handler.AccountClaims) error {
 	}
 
 	// JWT IDの取得
-	jwtID, wrErr := getJwtID(ac.Role, id)
+	jwtID, wrErr := getJwtID(ac.Role, ac.UserID)
 
 	if wrErr != nil {
 		logger.Error(wrErr)

--- a/internal/dogowner/controller/dogowner_controller.go
+++ b/internal/dogowner/controller/dogowner_controller.go
@@ -74,7 +74,5 @@ func (doc *dogOwnerController) DogOwnerSignUp(c echo.Context) error {
 		return wrErr
 	}
 
-	return c.JSON(http.StatusCreated, map[string]string{
-		"accessToken": token,
-	})
+	return c.JSON(http.StatusCreated, token)
 }

--- a/internal/dogowner/core/handler/dogowner_handler.go
+++ b/internal/dogowner/core/handler/dogowner_handler.go
@@ -18,7 +18,7 @@ import (
 )
 
 type IDogOwnerHandler interface {
-	DogOwnerSignUp(c echo.Context, doReq doDTO.DogOwnerReq) (string, error)
+	DogOwnerSignUp(c echo.Context, doReq doDTO.DogOwnerReq) (authDTO.IssuedJwT, error)
 }
 
 type dogOwnerHandler struct {
@@ -54,7 +54,7 @@ func NewDogOwnerHandler(
 // return:
 //   - string
 //   - error: error情報
-func (doh *dogOwnerHandler) DogOwnerSignUp(c echo.Context, doReq doDTO.DogOwnerReq) (string, error) {
+func (doh *dogOwnerHandler) DogOwnerSignUp(c echo.Context, doReq doDTO.DogOwnerReq) (authDTO.IssuedJwT, error) {
 	logger := log.GetLogger(c).Sugar()
 
 	// パスワードのハッシュ化
@@ -67,20 +67,20 @@ func (doh *dogOwnerHandler) DogOwnerSignUp(c echo.Context, doReq doDTO.DogOwnerR
 			wrErrors.NewDogOwnerClientErrorEType(),
 		)
 		logger.Error(wrErr)
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// EmailとPhoneNumberのバリデーション
 	if wrErr := validateEmailOrPhoneNumber(doReq); wrErr != nil {
 		logger.Error(wrErr)
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// JWT IDの生成
 	jwtID, wrErr := authHandler.GenerateJwtID(c)
 
 	if wrErr != nil {
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// requestからDogOwnerの構造体に詰め替え
@@ -103,12 +103,12 @@ func (doh *dogOwnerHandler) DogOwnerSignUp(c echo.Context, doReq doDTO.DogOwnerR
 
 	// Emailの重複チェック
 	if wrErr := doh.ar.CheckDuplicate(c, model.EmailField, dogOwnerCredential.Email); wrErr != nil {
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// PhoneNumberの重複チェック
 	if wrErr := doh.ar.CheckDuplicate(c, model.PhoneNumberField, dogOwnerCredential.PhoneNumber); wrErr != nil {
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// dogOwnerの作成する1トランザクション
@@ -134,29 +134,31 @@ func (doh *dogOwnerHandler) DogOwnerSignUp(c echo.Context, doReq doDTO.DogOwnerR
 
 	}); err != nil {
 		logger.Error("Transaction failed:", err)
-		return "", err
+		return authDTO.IssuedJwT{}, err
 	}
 
 	// 正常に終了
 	logger.Infof("Successfully created SignUp DogOwner: %v", dogOwnerCredential)
 
 	// 作成したDogOwnerの情報をdto詰め替え
-	dogOwnerDetail := authDTO.UserAuthInfoDTO{
-		UserID: dogOwnerCredential.AuthDogOwner.DogOwnerID.Int64,
-		JwtID:  dogOwnerCredential.AuthDogOwner.JwtID.String,
-		RoleID: core.DOGOWNER_ROLE,
+	dogOwnerDetail := authDTO.JwtInfoDTO{
+		AuthUserInfoDTO: authDTO.AuthUserInfoDTO{
+			UserID: dogOwnerCredential.AuthDogOwner.DogOwnerID.Int64,
+			RoleID: core.DOGOWNER_ROLE,
+		},
+		JwtID: dogOwnerCredential.AuthDogOwner.JwtID.String,
 	}
 
 	logger.Infof("dogOwnerDetail: %v", dogOwnerDetail)
 
 	// 署名済みのjwt token取得
-	token, wrErr := authHandler.GetSignedJwt(c, dogOwnerDetail)
+	token, refreshToken, wrErr := authHandler.GetSignedJwt(c, dogOwnerDetail)
 
 	if wrErr != nil {
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
-	return token, nil
+	return authDTO.IssuedJwT{AccessToken: token, RefreshToken: refreshToken}, nil
 }
 
 // validateEmailOrPhoneNumber: EmailかPhoneNumberの識別バリデーション。パスワード認証は、EmailかPhoneNumberで登録するため

--- a/internal/models/auth_dog_owners_model.go
+++ b/internal/models/auth_dog_owners_model.go
@@ -19,6 +19,7 @@ type AuthDogOwner struct {
 	AccessTokenExpiration  util.CustomTime `gorm:"column:access_token_expiration"`
 	RefreshTokenExpiration util.CustomTime `gorm:"column:refresh_token_expiration"`
 	JwtID                  sql.NullString  `gorm:"size:45;column:jwt_id"`
+	RefreshJwtID           sql.NullString  `gorm:"size:45;column:refresh_jwt_id"`
 	LoginAt                time.Time       `gorm:"column:login_at;not null;autoCreateTime"`
 
 	DogOwner   DogOwner      `gorm:"foreignKey:DogOwnerID;references:DogOwnerID"`

--- a/internal/org/controller/org_controller.go
+++ b/internal/org/controller/org_controller.go
@@ -63,7 +63,5 @@ func (o *orgController) OrgSignUp(c echo.Context) error {
 		return wrErr
 	}
 
-	return c.JSON(http.StatusCreated, map[string]string{
-		"accessToken": token,
-	})
+	return c.JSON(http.StatusCreated, token)
 }

--- a/internal/org/core/handler/org_handler.go
+++ b/internal/org/core/handler/org_handler.go
@@ -20,7 +20,7 @@ import (
 )
 
 type IOrgHandler interface {
-	OrgSignUp(c echo.Context, orgReq dto.OrgReq) (string, error)
+	OrgSignUp(c echo.Context, orgReq dto.OrgReq) (authDTO.IssuedJwT, error)
 }
 
 type orgHandler struct {
@@ -50,7 +50,7 @@ func NewOrgHandler(
 func (oh *orgHandler) OrgSignUp(
 	c echo.Context,
 	orgReq dto.OrgReq,
-) (string, error) {
+) (authDTO.IssuedJwT, error) {
 	logger := log.GetLogger(c).Sugar()
 
 	// パスワードのハッシュ化
@@ -63,19 +63,19 @@ func (oh *orgHandler) OrgSignUp(
 			wrErrors.NewOrgClientErrorEType(),
 		)
 		logger.Error(wrErr)
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// JWT IDの生成
 	jwtID, wrErr := authHandler.GenerateJwtID(c)
 
 	if wrErr != nil {
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// orgのEmailバリデーション
 	if wrErr := oh.af.OrgEmailValidate(c, orgReq.ContactEmail); wrErr != nil {
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
 	// requestからorgの構造体に詰め替え
@@ -145,24 +145,26 @@ func (oh *orgHandler) OrgSignUp(
 
 	}); err != nil {
 		logger.Error("Transaction failed:", err)
-		return "", err
+		return authDTO.IssuedJwT{}, err
 	}
 
 	// 作成したdogrunmgの情報をdto詰め替え
-	dogrunmgrDetail := authDTO.UserAuthInfoDTO{
-		UserID: orgInfo.AuthDogrunmg.DogrunmgID.Int64,
-		JwtID:  orgInfo.AuthDogrunmg.JwtID.String,
-		RoleID: core.DOGRUNMG_ADMIN_ROLE,
+	dogrunmgrDetail := authDTO.JwtInfoDTO{
+		AuthUserInfoDTO: authDTO.AuthUserInfoDTO{
+			UserID: orgInfo.AuthDogrunmg.DogrunmgID.Int64,
+			RoleID: core.DOGRUNMG_ADMIN_ROLE,
+		},
+		JwtID: orgInfo.AuthDogrunmg.JwtID.String,
 	}
 
 	logger.Infof("dogrunmgDetail: %v", dogrunmgrDetail)
 
 	// 署名済みのjwt token取得
-	token, wrErr := authHandler.GetSignedJwt(c, dogrunmgrDetail)
+	token, refreshToken, wrErr := authHandler.GetSignedJwt(c, dogrunmgrDetail)
 
 	if wrErr != nil {
-		return "", wrErr
+		return authDTO.IssuedJwT{}, wrErr
 	}
 
-	return token, nil
+	return authDTO.IssuedJwT{AccessToken: token, RefreshToken: refreshToken}, nil
 }

--- a/internal/org/core/handler/org_handler.go
+++ b/internal/org/core/handler/org_handler.go
@@ -20,7 +20,7 @@ import (
 )
 
 type IOrgHandler interface {
-	OrgSignUp(c echo.Context, orgReq dto.OrgReq) (authDTO.IssuedJwT, error)
+	OrgSignUp(c echo.Context, orgReq dto.OrgReq) (authDTO.IssuedJwtRes, error)
 }
 
 type orgHandler struct {
@@ -50,7 +50,7 @@ func NewOrgHandler(
 func (oh *orgHandler) OrgSignUp(
 	c echo.Context,
 	orgReq dto.OrgReq,
-) (authDTO.IssuedJwT, error) {
+) (authDTO.IssuedJwtRes, error) {
 	logger := log.GetLogger(c).Sugar()
 
 	// パスワードのハッシュ化
@@ -63,19 +63,19 @@ func (oh *orgHandler) OrgSignUp(
 			wrErrors.NewOrgClientErrorEType(),
 		)
 		logger.Error(wrErr)
-		return authDTO.IssuedJwT{}, wrErr
+		return authDTO.IssuedJwtRes{}, wrErr
 	}
 
 	// JWT IDの生成
 	jwtID, wrErr := authHandler.GenerateJwtID(c)
 
 	if wrErr != nil {
-		return authDTO.IssuedJwT{}, wrErr
+		return authDTO.IssuedJwtRes{}, wrErr
 	}
 
 	// orgのEmailバリデーション
 	if wrErr := oh.af.OrgEmailValidate(c, orgReq.ContactEmail); wrErr != nil {
-		return authDTO.IssuedJwT{}, wrErr
+		return authDTO.IssuedJwtRes{}, wrErr
 	}
 
 	// requestからorgの構造体に詰め替え
@@ -145,7 +145,7 @@ func (oh *orgHandler) OrgSignUp(
 
 	}); err != nil {
 		logger.Error("Transaction failed:", err)
-		return authDTO.IssuedJwT{}, err
+		return authDTO.IssuedJwtRes{}, err
 	}
 
 	// 作成したdogrunmgの情報をdto詰め替え
@@ -163,8 +163,8 @@ func (oh *orgHandler) OrgSignUp(
 	token, refreshToken, wrErr := authHandler.GetSignedJwt(c, dogrunmgrDetail)
 
 	if wrErr != nil {
-		return authDTO.IssuedJwT{}, wrErr
+		return authDTO.IssuedJwtRes{}, wrErr
 	}
 
-	return authDTO.IssuedJwT{AccessToken: token, RefreshToken: refreshToken}, nil
+	return authDTO.IssuedJwtRes{AccessToken: token, RefreshToken: refreshToken}, nil
 }

--- a/internal/wrcontext/wrcontext.go
+++ b/internal/wrcontext/wrcontext.go
@@ -1,8 +1,6 @@
 package wrcontext
 
 import (
-	"strconv"
-
 	"github.com/labstack/echo/v4"
 	"github.com/wanrun-develop/wanrun/internal/auth/core"
 	"github.com/wanrun-develop/wanrun/internal/auth/core/handler"
@@ -44,23 +42,11 @@ func GetVerifiedClaims(c echo.Context) (*handler.AccountClaims, error) {
 // return:
 //   - int64:	ユーザーID
 func GetLoginUserID(c echo.Context) (int64, error) {
-	logger := log.GetLogger(c).Sugar()
-
 	claims, err := GetVerifiedClaims(c)
 	if err != nil {
 		return 0, err
 	}
-	userID, err := strconv.ParseInt(claims.UserID, 10, 64)
-	if err != nil {
-		logger.Error(err)
-		err = errors.NewWRError(
-			nil,
-			"型の形式が異なっています。",
-			errors.NewAuthClientErrorEType(),
-		)
-		return 0, err
-	}
-	return userID, nil
+	return claims.UserID, nil
 }
 
 // GetLoginUserId: ログインユーザーのdogownerIDの取得
@@ -72,8 +58,6 @@ func GetLoginUserID(c echo.Context) (int64, error) {
 // return:
 //   - int64:	ユーザーID
 func GetLoginDogownerID(c echo.Context) (int64, error) {
-	logger := log.GetLogger(c).Sugar()
-
 	claims, err := GetVerifiedClaims(c)
 	if err != nil {
 		return 0, err
@@ -86,17 +70,7 @@ func GetLoginDogownerID(c echo.Context) (int64, error) {
 		)
 		return 0, err
 	}
-	userID, err := strconv.ParseInt(claims.UserID, 10, 64)
-	if err != nil {
-		logger.Error(err)
-		err = errors.NewWRError(
-			nil,
-			"型の形式が異なっています。",
-			errors.NewAuthClientErrorEType(),
-		)
-		return 0, err
-	}
-	return userID, nil
+	return claims.UserID, nil
 }
 
 // GetLoginUserRole: ログインユーザー（認証済み）のロールを取得する

--- a/migrate/migration_sql/000010_auth_dog_owners.up.sql
+++ b/migrate/migration_sql/000010_auth_dog_owners.up.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS auth_dog_owners (
     access_token_expiration timestamp,            -- アクセストークンの有効期限
     refresh_token_expiration timestamp,           -- リフレッシュトークンの有効期限（オプション）
     jwt_id varchar(45),
+    refresh_iwt_id varchar(45),
     si_refresh_token varchar(512),
     login_at timestamp
 );


### PR DESCRIPTION
## 概要
リフレッシュトークンでの認証トークン再発行処理の追加

## 変更点

- auth/dogowner/token
パスワード認証
```
{
    "password": "password",
    "email": "olivia@example.com",
    "authenticationType": "password" --固定
}
```
リフレッシュトークン認証
```
{
    "refreshToken": "{{refreshToken}}",
    "authenticationType": "refresh" --固定
}

```
- auth/dogowner/revoke でリフレッシュトークンの失効

## 影響範囲
認証


## 関連Issue

- 関連Issue: #73 
