### PR TITLE
ブックマーク済みドッグラン一覧の取得

### DIFF
--- a/cmd/wanrun.go
+++ b/cmd/wanrun.go
@@ -131,6 +131,7 @@ func newRouter(e *echo.Echo, dbConn *gorm.DB) {
 	dogrun.GET("/photo/src", dogrunController.GetDogrunPhoto, authMW.RoleAuthorization(authMW.DOGRUN_REFER))
 	dogrun.GET("/mst/tag", dogrunController.GetDogrunTagMst, authMW.RoleAuthorization(authMW.ALL))
 	dogrun.POST("/search", dogrunController.SearchAroundDogruns, authMW.RoleAuthorization(authMW.DOGRUN_SEARCH))
+	dogrun.POST("/bookmark", dogrunController.GetBookmarkedDogruns, authMW.RoleAuthorization(authMW.DOGRUN_SEARCH))
 
 	// dogOwner関連
 	dogOwnerController := newDogOwner(dbConn)

--- a/common/dto.go
+++ b/common/dto.go
@@ -17,3 +17,8 @@ func (ct WRTime) MarshalJSON() ([]byte, error) {
 	formatted := fmt.Sprintf("\"%s\"", ct.Format(F_yyyyMMddHHmmss))
 	return []byte(formatted), nil
 }
+
+type PaginationReq struct {
+	Count int `json:"count" validate:"min=1,max=60"`
+	Page  int `json:"page" validate:"min=1,max=100"`
+}

--- a/internal/dogrun/adapters/googleplace/field.go
+++ b/internal/dogrun/adapters/googleplace/field.go
@@ -35,7 +35,7 @@ const (
 )
 
 // リクエストに使うfieldMaskたち
-var BASE_FILEDS = []string{
+var BASE_FIELDS = []string{
 	F_ID_IO,
 	F_ADDRESSCOMPONENTS_LO,
 	F_SHORTFORMATTEDADDRESS_LO,
@@ -59,17 +59,21 @@ type IFieldMask interface {
 // 詳細情報用
 type BaseField struct{}
 
+func NewBaseField() IFieldMask {
+	return &BaseField{}
+}
+
 func (b BaseField) getValue() string {
-	return strings.Join(BASE_FILEDS, ",")
+	return strings.Join(BASE_FIELDS, ",")
 }
 
 /*
-search nearbyようにfieldに"palce."のプレフィックスを付与する
+search nearbyようにfieldに"place."のプレフィックスを付与する
 */
 func (b BaseField) getValueWPlaces() string {
 	// BASE_FILED_MASK のコピーを作成
-	fieldsWithPlace := make([]string, len(BASE_FILEDS))
-	copy(fieldsWithPlace, BASE_FILEDS)
+	fieldsWithPlace := make([]string, len(BASE_FIELDS))
+	copy(fieldsWithPlace, BASE_FIELDS)
 
 	// "place." をそれぞれの定数に付与
 	for i, field := range fieldsWithPlace {

--- a/internal/dogrun/adapters/repository/dogrun_repository.go
+++ b/internal/dogrun/adapters/repository/dogrun_repository.go
@@ -11,9 +11,13 @@ import (
 )
 
 type IDogrunRepository interface {
+	WithDogrun() IDogrunRepository
+	WithDogrunTags() IDogrunRepository
+	WithRegularBusinessHours() IDogrunRepository
+	WithSpecialBusinessHours() IDogrunRepository
 	GetDogrunByPlaceID(echo.Context, string) (model.Dogrun, error)
 	GetDogrunByID(string) (model.Dogrun, error)
-	FindDogrunByIDs([]int64) ([]model.Dogrun, error)
+	FindDogrunByIDs(echo.Context, []int64) ([]model.Dogrun, error)
 	GetDogrunByRectanglePointerOrPlaceId(echo.Context, dto.SearchAroundRectangleCondition, []string) ([]model.Dogrun, error)
 	GetDogrunByRectanglePointerAndDogrunTags(echo.Context, dto.SearchAroundRectangleCondition) ([]model.Dogrun, error)
 	GetTagMst(echo.Context) ([]model.TagMst, error)
@@ -28,15 +32,26 @@ func NewDogrunRepository(db *gorm.DB) IDogrunRepository {
 	return &dogrunRepository{db}
 }
 
+func (drr *dogrunRepository) WithDogrun() IDogrunRepository {
+	return &dogrunRepository{drr.db.Preload("Dogrun")}
+}
+func (drr *dogrunRepository) WithDogrunTags() IDogrunRepository {
+	return &dogrunRepository{drr.db.Preload("DogrunTags")}
+}
+func (drr *dogrunRepository) WithRegularBusinessHours() IDogrunRepository {
+	return &dogrunRepository{drr.db.Preload("RegularBusinessHours")}
+}
+func (drr *dogrunRepository) WithSpecialBusinessHours() IDogrunRepository {
+	return &dogrunRepository{drr.db.Preload("SpecialBusinessHours")}
+}
+
 /*
 PlaceIDで、ドッグランの取得
 */
 func (drr *dogrunRepository) GetDogrunByPlaceID(c echo.Context, placeID string) (model.Dogrun, error) {
 	logger := log.GetLogger(c).Sugar()
 	dogrun := model.Dogrun{}
-	if err := drr.db.Preload("DogrunTags").
-		Preload("RegularBusinessHours").
-		Preload("SpecialBusinessHours").
+	if err := drr.db.
 		Where("place_id = ?", placeID).
 		Find(&dogrun).Error; err != nil {
 		logger.Error(err)
@@ -65,10 +80,11 @@ func (drr *dogrunRepository) GetDogrunByID(id string) (model.Dogrun, error) {
 // return:
 //   - []model.Dogrun:	検索結果
 //   - error:	エラー
-func (drr *dogrunRepository) FindDogrunByIDs(ids []int64) ([]model.Dogrun, error) {
+func (drr *dogrunRepository) FindDogrunByIDs(c echo.Context, ids []int64) ([]model.Dogrun, error) {
 	dogruns := []model.Dogrun{}
 	if err := drr.db.Where("dogrun_id in ?", ids).Find(&dogruns).Error; err != nil {
-		return dogruns, err
+		log.GetLogger(c).Sugar()
+		return nil, errors.NewWRError(err, "DBからのdogrunデータ取得に失敗", errors.NewDogrunServerErrorEType())
 	}
 	return dogruns, nil
 }
@@ -86,9 +102,7 @@ func (drr *dogrunRepository) FindDogrunByIDs(ids []int64) ([]model.Dogrun, error
 func (drr *dogrunRepository) GetDogrunByRectanglePointerOrPlaceId(c echo.Context, condition dto.SearchAroundRectangleCondition, placeIDs []string) ([]model.Dogrun, error) {
 	logger := log.GetLogger(c).Sugar()
 	dogruns := []model.Dogrun{}
-	if err := drr.db.Preload("DogrunTags").
-		Preload("RegularBusinessHours").
-		Preload("SpecialBusinessHours").
+	if err := drr.db.
 		Where("(longitude BETWEEN ? AND ?) AND (latitude BETWEEN ? AND ?)",
 			condition.Target.Southwest.Longitude, condition.Target.Northeast.Longitude,
 			condition.Target.Southwest.Latitude, condition.Target.Northeast.Latitude).
@@ -117,10 +131,10 @@ func (drr *dogrunRepository) GetDogrunByRectanglePointerAndDogrunTags(c echo.Con
 			condition.Target.Southwest.Longitude, condition.Target.Northeast.Longitude,
 			condition.Target.Southwest.Latitude, condition.Target.Northeast.Latitude).
 		Where("dogrun_tags.tag_id IN ?", condition.IncludeDogrunTags).
-		Group("dogruns.dogrun_id"). // dogruns の重複を排除
-		Preload("DogrunTags").
-		Preload("RegularBusinessHours").
-		Preload("SpecialBusinessHours").
+		Group("dogruns.dogrun_id").      // dogruns の重複を排除
+		Preload("DogrunTags").           //where後にpreload
+		Preload("RegularBusinessHours"). //where後にpreload
+		Preload("SpecialBusinessHours"). //where後にpreload
 		Find(&dogruns).Error; err != nil {
 		logger.Error(err)
 		return nil, errors.NewWRError(err, "DBからのデータ取得に失敗", errors.NewDogrunServerErrorEType())

--- a/internal/dogrun/controller/dogrun_controller.go
+++ b/internal/dogrun/controller/dogrun_controller.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
+	"github.com/wanrun-develop/wanrun/common"
 	"github.com/wanrun-develop/wanrun/internal/dogrun/core/dto"
 	"github.com/wanrun-develop/wanrun/internal/dogrun/core/handler"
 	"github.com/wanrun-develop/wanrun/pkg/errors"
@@ -18,6 +19,7 @@ type IDogrunController interface {
 	GetDogrunTagMst(echo.Context) error
 	SearchAroundDogruns(echo.Context) error
 	GetDogrunPhoto(echo.Context) error
+	GetBookmarkedDogruns(echo.Context) error
 }
 
 type dogrunController struct {
@@ -157,4 +159,37 @@ func validateMaxPX(px string) error {
 		return errors.NewWRError(nil, "リクエストの画像サイズの指定が不正です。1以上4800以下である必要があります。", errors.NewDogrunClientErrorEType())
 	}
 	return nil
+}
+
+// GetBookmarkedDogruns: ブックマークしたドッグランの一覧取得
+//
+// args:
+//   - echo.Context:	コンテキスト
+//
+// return:
+// error:	エラー
+func (dc *dogrunController) GetBookmarkedDogruns(c echo.Context) error {
+	logger := log.GetLogger(c).Sugar()
+
+	pagination := common.PaginationReq{}
+	if err := c.Bind(&pagination); err != nil {
+		err = errors.NewWRError(err, "paginationが不正です", errors.NewDogrunClientErrorEType())
+		logger.Error(err)
+		return err
+	}
+
+	// バリデータのインスタンス作成
+	validate := validator.New()
+	//リクエストボディのバリデーション
+	if err := validate.Struct(pagination); err != nil {
+		err = errors.NewWRError(err, "paginationのバリデーションに違反しています", errors.NewDogrunClientErrorEType())
+		logger.Error(err)
+		return err
+	}
+
+	dogruns, err := dc.h.GetBookmarkedDogruns(c, pagination)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, dogruns)
 }

--- a/internal/dogrun/core/handler/dogrun_handler.go
+++ b/internal/dogrun/core/handler/dogrun_handler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/wanrun-develop/wanrun/common"
 	"github.com/wanrun-develop/wanrun/internal/dogrun/adapters/googleplace"
 	"github.com/wanrun-develop/wanrun/internal/dogrun/adapters/repository"
 	"github.com/wanrun-develop/wanrun/internal/dogrun/core/dto"
@@ -29,6 +30,7 @@ type IDogrunHandler interface {
 	SearchAroundAndTagDogruns(echo.Context, dto.SearchAroundRectangleCondition) ([]dto.DogrunLists, error)
 	getBookmarkedDogrunIDs(echo.Context, chan<- []int64)
 	GetDogrunPhotoSrc(echo.Context, string, string, string) (string, error)
+	GetBookmarkedDogruns(echo.Context, common.PaginationReq) ([]dto.DogrunLists, error)
 }
 
 type dogrunHandler struct {
@@ -75,7 +77,7 @@ func (h *dogrunHandler) GetDogrunDetail(c echo.Context, placeID string) (dto.Dog
 	}
 
 	//dbから取得
-	dogrunD, err := h.drr.GetDogrunByPlaceID(c, placeID)
+	dogrunD, err := h.drr.WithDogrunTags().WithRegularBusinessHours().WithSpecialBusinessHours().GetDogrunByPlaceID(c, placeID)
 	if err != nil {
 		return dto.DogrunDetail{}, err
 	}
@@ -137,7 +139,7 @@ func (h *dogrunHandler) SearchAroundDogruns(c echo.Context, condition dto.Search
 	go h.getBookmarkedDogrunIDs(c, bookmarkedDogrunIDsCH)
 
 	//base情報のFieldを使用
-	var baseFiled googleplace.IFieldMask = googleplace.BaseField{}
+	baseFiled := googleplace.NewBaseField()
 
 	//place情報の取得
 	dogrunsG, err := h.searchTextUpToSpecifiedTimes(c, payload, baseFiled)
@@ -151,14 +153,18 @@ func (h *dogrunHandler) SearchAroundDogruns(c echo.Context, condition dto.Search
 	}
 
 	//DBにある指定場所内のドッグランを取得
-	dogrunsD, err := h.drr.GetDogrunByRectanglePointerOrPlaceId(c, condition, dogrunGPlaceIDs)
+	dogrunsD, err := h.drr.
+		WithDogrunTags().
+		WithRegularBusinessHours().
+		WithSpecialBusinessHours().
+		GetDogrunByRectanglePointerOrPlaceId(c, condition, dogrunGPlaceIDs)
 	if err != nil {
 		return nil, err
 	}
 	logger.Infof("DBから取得数:%d", len(dogrunsD))
 
 	//検索結果からレスポンスを作成
-	dogrunLists, err := h.integrateDogrunInfos(dogrunsG, dogrunsD)
+	dogrunLists, err := integrateDogrunInfos(dogrunsG, dogrunsD)
 	logger.Infof("レスポンス件数:%d", len(dogrunLists))
 	if err != nil {
 		return nil, err
@@ -637,7 +643,7 @@ func (h *dogrunHandler) searchTextUpToSpecifiedTimes(c echo.Context, payload goo
 検索結果をもとに、レスポンス用のDTOを作成
 placeIdで、両方にあるデータと、DBにのみあるデータ等で分けて、それぞれ統合する
 */
-func (h *dogrunHandler) integrateDogrunInfos(dogrunsG []googleplace.BaseResource, dogrunsD []model.Dogrun) ([]dto.DogrunLists, error) {
+func integrateDogrunInfos(dogrunsG []googleplace.BaseResource, dogrunsD []model.Dogrun) ([]dto.DogrunLists, error) {
 	//google情報からplaceIdをkeyにmapにまとめる
 	dogrunsGWithPlaceID := make(map[string]googleplace.BaseResource, len(dogrunsG))
 	for _, dogrunG := range dogrunsG {
@@ -819,28 +825,6 @@ func resolvePlacePhotos(dogrunG googleplace.BaseResource) []dto.PhotoInfo {
 	return photos
 }
 
-// GenerateSetDogrunIDs: dogrunIDがないデータに対して、dogrunsテーブルに登録し、IDをdtoにセットする
-//
-// args:
-//   - echo.Context:	コンテキスト
-//   - []dto.DogrunLists:	dogrunIDメンテを行う対象のdto
-//
-// return:
-//   - error:	エラー
-func (h *dogrunHandler) GenerateSetDogrunIDs(c echo.Context, dogrunLists []dto.DogrunLists) error {
-	for i := range dogrunLists {
-		if dogrunLists[i].DogrunID == 0 {
-			//id発行
-			dogrunID, err := h.persistenceDogrunPlaceId(c, dogrunLists[i].PlaceId)
-			if err != nil {
-				return err
-			}
-			dogrunLists[i].DogrunID = dogrunID
-		}
-	}
-	return nil
-}
-
 // persistenceDogrunPlaceId: DBにないplaceIdをDBへ保存して、PKを発行させる
 //
 // args:
@@ -872,10 +856,10 @@ func (h *dogrunHandler) persistenceDogrunPlaceId(c echo.Context, placeId string)
 //
 // return:
 //   - []model.Dogrun:	チェック済みドッグラン情報
-func excludeInsufficientDogrunInfo(c echo.Context, dogrunsDParam []dto.DogrunLists) []dto.DogrunLists {
+func excludeInsufficientDogrunInfo(c echo.Context, dogrunListsP []dto.DogrunLists) []dto.DogrunLists {
 	logger := log.GetLogger(c).Sugar()
 	dogruns := []dto.DogrunLists{}
-	for _, dogrun := range dogrunsDParam {
+	for _, dogrun := range dogrunListsP {
 		if dogrun.IsSufficientInfo() {
 			dogruns = append(dogruns, dogrun)
 		} else {
@@ -884,4 +868,141 @@ func excludeInsufficientDogrunInfo(c echo.Context, dogrunsDParam []dto.DogrunLis
 	}
 
 	return dogruns
+}
+
+// GenerateSetDogrunIDs: dogrunIDがないデータに対して、dogrunsテーブルに登録し、IDをdtoにセットする
+//
+// args:
+//   - echo.Context:	コンテキスト
+//   - []dto.DogrunLists:	dogrunIDメンテを行う対象のdto
+//
+// return:
+//   - error:	エラー
+func (h *dogrunHandler) GenerateSetDogrunIDs(c echo.Context, dogrunLists []dto.DogrunLists) error {
+	for i := range dogrunLists {
+		if dogrunLists[i].DogrunID == 0 {
+			//id発行
+			dogrunID, err := h.persistenceDogrunPlaceId(c, dogrunLists[i].PlaceId)
+			if err != nil {
+				return err
+			}
+			dogrunLists[i].DogrunID = dogrunID
+		}
+	}
+	return nil
+}
+
+// GetBookmarkedDogruns: ログインユーザーのブックマーク済みドッグランの一覧を取得
+//
+// args:
+//   - echo.Context:	コンテキスト
+//
+// return:
+//   - []dto.DogrunLists:	ドッグラン一覧
+//   - error:	エラー
+func (h *dogrunHandler) GetBookmarkedDogruns(c echo.Context, page common.PaginationReq) ([]dto.DogrunLists, error) {
+	logger := log.GetLogger(c).Sugar()
+
+	bookmarkedDogrunIDs, err := h.bf.GetAllUserBookmarksByPage(c, page)
+	if err != nil {
+		return nil, err
+	}
+
+	//0件バリデーション
+	if len(bookmarkedDogrunIDs) < 1 {
+		logger.Info("ブックマークしたドッグランが存在しません")
+		return []dto.DogrunLists{}, nil
+	}
+	logger.Info("取得対象", bookmarkedDogrunIDs)
+
+	//ドッグランのselect
+	bookmarkedDogruns, err := h.drr.
+		WithDogrunTags().
+		WithRegularBusinessHours().
+		WithSpecialBusinessHours().
+		FindDogrunByIDs(c, bookmarkedDogrunIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	//placeIDの抽出
+	placeIds := []string{}
+	for _, dogrun := range bookmarkedDogruns {
+		if dogrun.PlaceId.Valid {
+			placeIds = append(placeIds, dogrun.PlaceId.String)
+		}
+	}
+
+	//goroutineでgoogle検索
+	googleBaseField := googleplace.NewBaseField()
+	googleResultCh := make(chan googleplace.BaseResource)
+	defer close(googleResultCh)
+
+	for _, placeId := range placeIds {
+		go h.AsyncSearchGooglePlaceByPlaceIds(c, placeId, googleBaseField, googleResultCh)
+	}
+
+	//非同期google検索結果を受け取る
+	dogrunG := []googleplace.BaseResource{}
+	for range placeIds {
+		googleResult := <-googleResultCh
+
+		if googleResult.ID == "" {
+			err := errors.NewWRError(nil, "指定されたPlaceIdのデータが存在しません。", errors.NewDogrunClientErrorEType())
+			logger.Error(err)
+			continue //TODO: 落とすべきではないか、要検討
+		}
+		dogrunG = append(dogrunG, googleResult)
+	}
+
+	//レスポンスDTOへ統合
+	dogrunLists, err := integrateDogrunInfos(dogrunG, bookmarkedDogruns)
+	if err != nil {
+		return nil, err
+	}
+
+	//ドッグラン情報の過不足フィルター
+	dogrunLists = excludeInsufficientDogrunInfo(c, dogrunLists)
+
+	// mapに変換してIsBookmarkedフラグを更新
+	bookmarkedDogrunIDMap := util.ConvertSliceToMap(bookmarkedDogrunIDs, func(i int64) int64 { return i })
+	for i := range dogrunLists {
+		if _, exist := bookmarkedDogrunIDMap[int64(dogrunLists[i].DogrunID)]; exist {
+			dogrunLists[i].IsBookmarked = true
+		}
+	}
+
+	return dogrunLists, nil
+}
+
+// AsyncSearchGooglePlaceByPlaceIds: 非同期によるPlaceIDでのgoogle place検索
+//
+// args:
+//   - echo.Context:	コンテキスト
+//   - string:	placeID
+//   - googleplace.IFieldMask:	検索対象のgoogle field mask
+//   - chan<- google.BaseResource:	レスポンス入れる受信専用チャネル
+//
+// return:
+func (h *dogrunHandler) AsyncSearchGooglePlaceByPlaceIds(c echo.Context, placeID string, fields googleplace.IFieldMask, resCh chan<- googleplace.BaseResource) {
+	logger := log.GetLogger(c).Sugar()
+
+	//place情報の取得
+	resG, err := h.rest.GETPlaceInfo(c, placeID, fields)
+	if err != nil {
+		return
+	}
+	logger.Info("Google Place APIによって、ドッグラン情報の取得成功")
+
+	// JSONデータを構造体にデコード
+	var dogrunG googleplace.BaseResource
+	err = json.Unmarshal(resG, &dogrunG)
+	if err != nil {
+		err = errors.NewWRError(nil, "google apiレスポンスの変換に失敗しました。", errors.NewDogrunServerErrorEType())
+		logger.Error(err)
+		resCh <- googleplace.BaseResource{}
+		return
+	}
+
+	resCh <- dogrunG
 }

--- a/internal/dogrun/facade/dogrun_facade.go
+++ b/internal/dogrun/facade/dogrun_facade.go
@@ -31,7 +31,7 @@ func NewDogrunFacade(drr repository.IDogrunRepository) IDogrunFacade {
 func (h *dogrunFacade) CheckDogrunExistByIDs(c echo.Context, dogrunIDs []int64) error {
 	logger := log.GetLogger(c).Sugar()
 
-	dogrunResults, err := h.drr.FindDogrunByIDs(dogrunIDs)
+	dogrunResults, err := h.drr.FindDogrunByIDs(c, dogrunIDs)
 	if err != nil {
 		err = errors.NewWRError(err, "dogrun存在チェックでエラー", errors.NewDogrunClientErrorEType())
 		return err

--- a/internal/interaction/adapters/repository/interaction_repository.go
+++ b/internal/interaction/adapters/repository/interaction_repository.go
@@ -13,6 +13,7 @@ import (
 
 type IBookmarkRepository interface {
 	GetBookmarks(echo.Context, int64) ([]model.DogrunBookmark, error)
+	GetBookmarksByPage(echo.Context, int64, int, int) ([]model.DogrunBookmark, error)
 	AddBookmark(echo.Context, int64, int64) (int64, error)
 	FindDogrunBookmark(echo.Context, int64, int64) (model.DogrunBookmark, error)
 	DeleteBookmark(echo.Context, []int64, int64) error
@@ -27,6 +28,7 @@ func NewBookmarkRepository(db *gorm.DB) IBookmarkRepository {
 }
 
 // GetBookmarks: dogownerのブックマークを取得
+// 新しい順で全件取得
 //
 // args:
 //   - echo.Context:	コンテキスト
@@ -41,6 +43,36 @@ func (r *bookmarkRepository) GetBookmarks(c echo.Context, dogownerID int64) ([]m
 	bookmarks := []model.DogrunBookmark{}
 	if err := r.db.
 		Where("dog_owner_id = ?", dogownerID).
+		Order("saved_at DESC").
+		Find(&bookmarks).Error; err != nil {
+		logger.Error(err)
+		err := errors.NewWRError(err, "dogrun_bookmarksの検索に失敗しました。", errors.NewInteractionServerErrorEType())
+		return nil, err
+	}
+
+	return bookmarks, nil
+}
+
+// GetBookmarks: dogownerのブックマークを取得
+// 新しい順でpageで指定数の取得
+//
+// args:
+//   - echo.Context:	コンテキスト
+//   - int64:	ドッグオーナーID
+//   - common.PaginationReq:	ページネーション設定
+//
+// return:
+//   - []model.DogrunBookmark:	検索結果
+//   - error:	エラー
+func (r *bookmarkRepository) GetBookmarksByPage(c echo.Context, dogownerID int64, limit int, offset int) ([]model.DogrunBookmark, error) {
+	logger := log.GetLogger(c).Sugar()
+
+	bookmarks := []model.DogrunBookmark{}
+	if err := r.db.
+		Where("dog_owner_id = ?", dogownerID).
+		Order("saved_at DESC").
+		Limit(limit).
+		Offset(offset).
 		Find(&bookmarks).Error; err != nil {
 		logger.Error(err)
 		err := errors.NewWRError(err, "dogrun_bookmarksの検索に失敗しました。", errors.NewInteractionServerErrorEType())

--- a/internal/interaction/core/dto/interaction_req_dto.go
+++ b/internal/interaction/core/dto/interaction_req_dto.go
@@ -2,19 +2,19 @@ package dto
 
 // bookmark 登録用
 type BookmarkAddReq struct {
-	DogrunIDs []int64 `json:"bookmark_dogrun_id" validate:"required,notEmpty"`
+	DogrunIDs []int64 `json:"bookmarkDogrunId" validate:"required,notEmpty"`
 }
 
 type BookmarkDeleteReq struct {
-	DogrunIDs []int64 `json:"bookmark_dogrun_id" validate:"required,notEmpty"`
+	DogrunIDs []int64 `json:"bookmarkDogrunId" validate:"required,notEmpty"`
 }
 
 type CheckinReq struct {
-	DogrunID int64   `json:"dogrun_id" validate:"required"`
-	DogIDs   []int64 `json:"dog_id" validate:"required"`
+	DogrunID int64   `json:"dogrunId" validate:"required"`
+	DogIDs   []int64 `json:"dogId" validate:"required"`
 }
 
 type CheckoutReq struct {
-	DogrunID int64   `json:"dogrun_id" validate:"required"`
-	DogIDs   []int64 `json:"dog_id" validate:"required"`
+	DogrunID int64   `json:"dogrunId" validate:"required"`
+	DogIDs   []int64 `json:"dogId" validate:"required"`
 }

--- a/internal/interaction/facade/interaction_facade.go
+++ b/internal/interaction/facade/interaction_facade.go
@@ -2,12 +2,14 @@ package facade
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/wanrun-develop/wanrun/common"
 	"github.com/wanrun-develop/wanrun/internal/interaction/adapters/repository"
 	"github.com/wanrun-develop/wanrun/internal/wrcontext"
 )
 
 type IBookmarkFacade interface {
 	GetAllUserBookmarks(echo.Context) ([]int64, error)
+	GetAllUserBookmarksByPage(echo.Context, common.PaginationReq) ([]int64, error)
 }
 
 type bookmarkFacade struct {
@@ -34,6 +36,36 @@ func (f *bookmarkFacade) GetAllUserBookmarks(c echo.Context) ([]int64, error) {
 	}
 
 	bookmarks, err := f.r.GetBookmarks(c, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	bookmarkedDogrunIDs := []int64{}
+	for _, bookmark := range bookmarks {
+		bookmarkedDogrunIDs = append(bookmarkedDogrunIDs, bookmark.DogrunID.Int64)
+	}
+
+	return bookmarkedDogrunIDs, nil
+}
+
+// GetAllUserBookmarksByPage: ログインユーザーのブックマークを取得
+// paginationあり
+// args:
+//   - echo.Context:	コンテキスト
+//
+// return:
+//   - []int64:	bookmarkIDs
+//   - error:	エラー
+func (f *bookmarkFacade) GetAllUserBookmarksByPage(c echo.Context, page common.PaginationReq) ([]int64, error) {
+	// ログインユーザーIDの取得
+	userID, err := wrcontext.GetLoginUserID(c)
+	if err != nil {
+		return nil, err
+	}
+
+	limit := page.Count
+	offset := page.Count * (page.Page - 1)
+	bookmarks, err := f.r.GetBookmarksByPage(c, userID, limit, offset)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## 概要

ブックマーク済みドッグラン一覧の取得

## 変更点

- POST: ~/dogrun/bookmark
```
{
    "count": 10,
    "page": 1
}
```
- ブックマーク追加リクエストボディをキャメルケースへ
```
{
    "bookmarkDogrunId": [2,4]
}
```

## 影響範囲
ドッグラン検索

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- 関連Issue: #190 
